### PR TITLE
test/travis: Run test suite with IOC and simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,10 @@ jobs:
 # Different compilers: gcc and clang
 
   - env: BASE=7.0 SET=latest
+    script:
+    - test/install-pytest-pyepics-p4p.sh
+    - test/test-pytest-pyepics-p4p.sh
+    - make -C test test-ioc-with-sim
 
   - env: BASE=7.0 SET=latest
     compiler: clang

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,2 @@
+test-ioc-with-sim:
+	./test-ioc-with-sim.sh

--- a/test/install-mini-conda.sh
+++ b/test/install-mini-conda.sh
@@ -1,0 +1,10 @@
+#/bin/sh
+set -e -x
+
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+conda init bash

--- a/test/install-pytest-pyepics-p4p.sh
+++ b/test/install-pytest-pyepics-p4p.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e -x
+
+sudo pip install pytest
+sudo pip install pyepics
+sudo pip install p4p
+
+sudo apt-get install pip3 || :
+sudo pip3 install pytest || :
+sudo pip3 install pyepics || :
+sudo pip3 install p4p || :

--- a/test/pyTests/doRunTests.sh
+++ b/test/pyTests/doRunTests.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+set -x
+
+run_pytest ()
+{
+  echo CONDA_PREFIX="$CONDA_PREFIX"
+  if type pytest; then
+    pytest "$@" || exit 1
+  elif test "$CONDA_PREFIX"; then
+      echo pytest "$@"
+      pytest "$@"
+  else
+    echo $PYTHON $VIRTUALENVDIR/bin/pytest "$@"
+    $PYTHON $VIRTUALENVDIR/bin/pytest "$@" || exit 1
+  fi
+}
+
+echo "$0" "$@"
+../test-pytest-pyepics-p4p.sh || :
+
+
+if test -n "$1"; then
+   TESTEDMOTORAXIS=$1
+   PREFIX=${1%:*}
+   TESTEDMOTORADDR=${1##*:m}
+   TESTEDMCUASYN=$PREFIX:MCU1:asyn
+   echo TESTEDMOTORAXIS=$TESTEDMOTORAXIS
+   echo TESTEDMOTORADDR=$TESTEDMOTORADDR
+   echo TESTEDMCUASYN=$TESTEDMCUASYN
+   shift 1
+else
+  echo >&2 "$0 <PV> [numruns] [testfile.py]"
+  exit 1
+fi
+
+
+files=""
+numruns=1
+while test -n "$1" && test -f "$1"; do
+    files="$files $1"
+    shift 1
+done
+
+if test -n "$1" && test "$1" -ne 0; then
+    numruns=$1
+    shift 1
+else
+    numruns=1
+fi
+
+
+#if test -z "$EPICS_CA_ADDR_LIST" && test -z "$EPICS_CA_AUTO_ADDR_LIST"; then
+#  if EPICS_CA_ADDR_LIST=127.0.1 EPICS_CA_AUTO_ADDR_LIST=NO caget $TESTEDMOTORAXIS.RBV >/dev/null 2>&1; then
+#    EPICS_CA_ADDR_LIST=127.0.1
+#    EPICS_CA_AUTO_ADDR_LIST=NO
+#    export EPICS_CA_ADDR_LIST EPICS_CA_AUTO_ADDR_LIST
+#  fi
+#fi
+
+while test $numruns -gt 0; do
+  #if ! caget $TESTEDMOTORAXIS.RBV >/dev/null 2>/dev/null; then
+  #  echo >&2 caget $TESTEDMOTORAXIS failed
+  #  exit 1
+  #fi
+  export TESTEDMOTORADDR TESTEDMOTORAXIS TESTEDMCUASYN
+  if test -n "$files"; then
+    files=$(echo $files | sort)
+    echo files=$files
+    for file in $files; do
+      echo file=$file
+      run_pytest "$@" $file || exit 1
+    done
+  else
+    py=$(echo *.py | sort)
+    echo py=$py
+    for p in $py
+    do
+      run_pytest "$@" $p || exit 1
+    done
+  fi
+  echo Runs left=$numruns
+  numruns=$(($numruns - 1))
+done

--- a/test/pyTests/runTests.sh
+++ b/test/pyTests/runTests.sh
@@ -15,232 +15,165 @@
 # run specif test on a motor PV a couple of times
 # ./runTests.sh IOC:m1 100_Record-HOMF.py 4
 
-if test -e $HOME/.bash_profile; then
-   . $HOME/.bash_profile
-fi
-
-# First of all, check for whitespace damage (TAB, trailing WS
-../checkws.sh || {
-  echo >&2   ../checkws.sh failed
-  exit 1
-}
-
-# Those values should work as default
-# They may be overwrtitten further down
-PYTEST=pytest
-PYTHON=python3
-
-##############################################################################
-# functions
-#
-#
-checkAndInstallSystemPackage()
-{
-  BINARYNAME=$1
-  PACKAGENAME=$2
-  if ! which $BINARYNAME; then
-    if which yum >/dev/null 2>&1; then
-      sudo yum install $PACKAGENAME || {
-        echo >&2 failed: sudo yum install $PACKAGENAME
-        return 1
-      }
-    fi
-    if which apt-get >/dev/null 2>&1; then
-      sudo apt-get install $PACKAGENAME || {
-        echo >&2 failed: sudo apt-get install $PACKAGENAME
-        return 1
-      }
-    fi
-    return 1
+if ! type pytest; then
+  # more things to do, either conda or virtualenv is our friend
+  if test -e $HOME/.bash_profile; then
+     . $HOME/.bash_profile
   fi
-}
 
-########################################
-checkAndInstallPythonPackage()
-{
-  IMPORTNAME=$1
-
-  if ! python -c "import $IMPORTNAME" >/dev/null 2>&1; then
-    while test $# -gt 1; do
-      shift
-      PACKAGEINSTALL=$1
-      echo failed: $PYTHON -c "import $IMPORTNAME"
-      $PACKAGEINSTALL && return 0
-    done
-    echo >&1  $PACKAGEINSTALL failed
-    exit 1
-  fi
-}
-##############################################################################
-if ! which conda >/dev/null 2>&1; then
-  # This is Mac OS
-  #URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-  #wget $URL || {
-    #echo >&2 wget $URL failed
-    #exit 1
-  #}
-  # conda is preferred over virtualenv
-  # But: if we have virtualenv, use it
-  if ! which virtualenv; then
-    checkAndInstallSystemPackage conda anaconda || {
-      # conda installation failed, fall back to virtualenv
-      checkAndInstallSystemPackage virtualenv python-virtualenv || {
-        echo >2 "could not install virtualenv"
-        exit 1
-      }
-    }
-  fi
-fi
-
-
-##############################################################################
-if which conda >/dev/null 2>&1; then
-  conda activate pyepicsPytestPVApy || {
-    echo >&2 conda activate pyepicsPytestPVApy failed
-    conda create -n  pyepicsPytestPVApy
+  # First of all, check for whitespace damage (TAB, trailing WS
+  ../checkws.sh || {
+    echo >&2   ../checkws.sh failed
     exit 1
   }
-  checkAndInstallPythonPackage pytest "conda install -c conda-forge pyTest"
-  checkAndInstallPythonPackage epics  "conda install -c https://conda.anaconda.org/GSECARS pyepics" "conda install pyepics"
-else
-  if ! type virtualenv >/dev/null 2>&1; then
-    echo >&2 virtualenv not found.
-    exit 1
+
+  # Those values should work as default
+  # They may be overwrtitten further down
+  PYTEST=pytest
+  PYTHON=python3
+
+  ##############################################################################
+  # functions
+  #
+  #
+  checkAndInstallSystemPackage()
+  {
+    BINARYNAME=$1
+    PACKAGENAME=$2
+    if ! which $BINARYNAME; then
+      if which yum >/dev/null 2>&1; then
+        sudo yum install $PACKAGENAME || {
+          echo >&2 failed: sudo yum install $PACKAGENAME
+          return 1
+        }
+      fi
+      if which apt-get >/dev/null 2>&1; then
+        sudo apt-get install $PACKAGENAME || {
+          echo >&2 failed: sudo apt-get install $PACKAGENAME
+          return 1
+        }
+      fi
+      return 1
+    fi
+  }
+
+  ########################################
+  checkAndInstallPythonPackage()
+  {
+    IMPORTNAME=$1
+
+    if ! python -c "import $IMPORTNAME" >/dev/null 2>&1; then
+      while test $# -gt 1; do
+        shift
+        PACKAGEINSTALL=$1
+        echo failed: $PYTHON -c "import $IMPORTNAME"
+        $PACKAGEINSTALL && return 0
+      done
+      echo >&1  $PACKAGEINSTALL failed
+      exit 1
+    fi
+  }
+  ##############################################################################
+  if ! which conda >/dev/null 2>&1; then
+    # This is Mac OS
+    #URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+    #wget $URL || {
+      #echo >&2 wget $URL failed
+      #exit 1
+    #}
+    # conda is preferred over virtualenv
+    # But: if we have virtualenv, use it
+    if ! which virtualenv; then
+      checkAndInstallSystemPackage conda anaconda || {
+        # conda installation failed, fall back to virtualenv
+        checkAndInstallSystemPackage virtualenv python-virtualenv || {
+          echo >2 "could not install virtualenv"
+          exit 1
+        }
+      }
+    fi
   fi
-  if which python3.7 >/dev/null 2>&1; then
-    PYTHON=python3.7
-  elif which python36 >/dev/null 2>&1; then
-    PYTHON=python37
-  elif which python3.6 >/dev/null 2>&1; then
-    PYTHON=python3.6
-  elif which python36 >/dev/null 2>&1; then
-    PYTHON=python36
-  elif which python3.4 >/dev/null 2>&1; then
-    PYTHON=python3.4
-    # need $ pip install "pytest<5"
-    PYTEST="pytest<5"
-  else
-    echo >&2 "No pyton 3.7, 3.6, 36 or 3.4 found"
-    exit 1
-  fi
-  VIRTUALENVDIR=virtual$PYTHON
-  if test -r $VIRTUALENVDIR/bin/activate; then
-    .  $VIRTUALENVDIR/bin/activate
-  else
-    virtualenv --python=$PYTHON $VIRTUALENVDIR || {
-      echo >&2 virtualenv failed
+
+
+  ##############################################################################
+  if which conda >/dev/null 2>&1; then
+    conda activate pyepicsPytestPVApy || {
+      echo >&2 conda activate pyepicsPytestPVApy failed
+      conda create -n  pyepicsPytestPVApy
       exit 1
     }
-  fi
-  if test -r $VIRTUALENVDIR/bin/activate; then
-    .  $VIRTUALENVDIR/bin/activate
-  fi
-  checkAndInstallPythonPackage epics "pip3 install pyepics" "pip install pyepics" &&
-    checkAndInstallPythonPackage pytest "pip3 install $PYTEST" "pip install $PYTEST" || {
-      echo >&2 Installation problem:
-      echo >&2 pip not found
-      echo >&2 easy_install not found
+    checkAndInstallPythonPackage pytest "conda install -c conda-forge pyTest"
+    checkAndInstallPythonPackage epics  "conda install -c https://conda.anaconda.org/GSECARS pyepics" "conda install pyepics"
+  else
+    if ! type virtualenv >/dev/null 2>&1; then
+      echo >&2 virtualenv not found.
       exit 1
-    }
-fi
-
-checkAndInstallPythonPackage p4p "pip3 install p4p" "pip install p4p"
-
-
-# See if we have a local EPICS installation
-uname_s=$(uname -s 2>/dev/null || echo unknown)
-uname_m=$(uname -m 2>/dev/null || echo unknown)
-INSTALLED_EPICS=../../../.epics.$(hostname).$uname_s.$uname_m
-if test -r $INSTALLED_EPICS; then
-  echo INSTALLED_EPICS=$INSTALLED_EPICS
-. $INSTALLED_EPICS
-fi
-
-if test -z "$PYEPICS_LIBCA"; then
-    MYLIB=$EPICS_BASE/lib/$EPICS_HOST_ARCH/libca.so
-    if test -r "$MYLIB"; then
-      PYEPICS_LIBCA=$MYLIB
-      export PYEPICS_LIBCA
+    fi
+    if which python3.7 >/dev/null 2>&1; then
+      PYTHON=python3.7
+    elif which python36 >/dev/null 2>&1; then
+      PYTHON=python37
+    elif which python3.6 >/dev/null 2>&1; then
+      PYTHON=python3.6
+    elif which python3.5 >/dev/null 2>&1; then
+      PYTHON=python3.5
+    elif which python36 >/dev/null 2>&1; then
+      PYTHON=python36
+    elif which python3.4 >/dev/null 2>&1; then
+      PYTHON=python3.4
+      # need $ pip install "pytest<5"
+      PYTEST="pytest<5"
     else
-      MYLIB=$EPICS_BASE/lib/$EPICS_HOST_ARCH/libca.dylib
+      echo >&2 "No pyton 3.7, 3.6, 36 or 3.4 found"
+      exit 1
+    fi
+    VIRTUALENVDIR=virtual$PYTHON
+    if test -r $VIRTUALENVDIR/bin/activate; then
+      .  $VIRTUALENVDIR/bin/activate
+    else
+      virtualenv --python=$PYTHON $VIRTUALENVDIR || {
+        echo >&2 virtualenv failed
+        exit 1
+      }
+    fi
+    if test -r $VIRTUALENVDIR/bin/activate; then
+      .  $VIRTUALENVDIR/bin/activate
+    fi
+    checkAndInstallPythonPackage epics "pip3 install pyepics" "pip install pyepics" &&
+      checkAndInstallPythonPackage pytest "pip3 install $PYTEST" "pip install $PYTEST" || {
+        echo >&2 Installation problem:
+        echo >&2 pip not found
+        echo >&2 easy_install not found
+        exit 1
+      }
+  fi
+
+  checkAndInstallPythonPackage p4p "pip3 install p4p" "pip install p4p"
+
+
+  # See if we have a local EPICS installation
+  uname_s=$(uname -s 2>/dev/null || echo unknown)
+  uname_m=$(uname -m 2>/dev/null || echo unknown)
+  INSTALLED_EPICS=../../../.epics.$(hostname).$uname_s.$uname_m
+  if test -r $INSTALLED_EPICS; then
+    echo INSTALLED_EPICS=$INSTALLED_EPICS
+  . $INSTALLED_EPICS
+  fi
+
+  if test -z "$PYEPICS_LIBCA"; then
+      MYLIB=$EPICS_BASE/lib/$EPICS_HOST_ARCH/libca.so
       if test -r "$MYLIB"; then
         PYEPICS_LIBCA=$MYLIB
         export PYEPICS_LIBCA
+      else
+        MYLIB=$EPICS_BASE/lib/$EPICS_HOST_ARCH/libca.dylib
+        if test -r "$MYLIB"; then
+          PYEPICS_LIBCA=$MYLIB
+          export PYEPICS_LIBCA
+        fi
       fi
-    fi
-fi &&
-
-echo "$0" "$@"
-if test -n "$1"; then
-   TESTEDMOTORAXIS=$1
-   PREFIX=${1%:*}
-   TESTEDMOTORADDR=${1##*:m}
-   TESTEDMCUASYN=$PREFIX:MCU1:asyn
-   echo TESTEDMOTORAXIS=$TESTEDMOTORAXIS
-   echo TESTEDMOTORADDR=$TESTEDMOTORADDR
-   echo TESTEDMCUASYN=$TESTEDMCUASYN
-   shift 1
-else
-  echo >&2 "$0 <PV> [numruns] [testfile.py]"
-  exit 1
+  fi &&
+  export VIRTUALENVDIR
+  export CONDA_PREFIX
 fi
-
-
-files=""
-numruns=1
-while test -n "$1" && test -f "$1"; do
-    files="$files $1"
-    shift 1
-done
-
-if test -n "$1" && test "$1" -ne 0; then
-    numruns=$1
-    shift 1
-else
-    numruns=1
-fi
-
-run_pytest ()
-{
-  echo CONDA_PREFIX="$CONDA_PREFIX"
-  if test "$CONDA_PREFIX"; then
-      echo pytest "$@"
-      pytest "$@"
-  else
-    echo $PYTHON $VIRTUALENVDIR/bin/pytest "$@"
-    $PYTHON $VIRTUALENVDIR/bin/pytest "$@" || exit 1
-  fi
-}
-
-#if test -z "$EPICS_CA_ADDR_LIST" && test -z "$EPICS_CA_AUTO_ADDR_LIST"; then
-#  if EPICS_CA_ADDR_LIST=127.0.1 EPICS_CA_AUTO_ADDR_LIST=NO caget $TESTEDMOTORAXIS.RBV >/dev/null 2>&1; then
-#    EPICS_CA_ADDR_LIST=127.0.1
-#    EPICS_CA_AUTO_ADDR_LIST=NO
-#    export EPICS_CA_ADDR_LIST EPICS_CA_AUTO_ADDR_LIST
-#  fi
-#fi
-
-while test $numruns -gt 0; do
-  #if ! caget $TESTEDMOTORAXIS.RBV >/dev/null 2>/dev/null; then
-  #  echo >&2 caget $TESTEDMOTORAXIS failed
-  #  exit 1
-  #fi
-  export TESTEDMOTORADDR TESTEDMOTORAXIS TESTEDMCUASYN
-  if test -n "$files"; then
-    files=$(echo $files | sort)
-    echo files=$files
-    for file in $files; do
-      echo file=$file
-      run_pytest "$@" $file || exit 1
-    done
-  else
-    py=$(echo *.py | sort)
-    echo py=$py
-    for p in $py
-    do
-      run_pytest "$@" $p || exit 1
-    done
-  fi
-  echo Runs left=$numruns
-  numruns=$(($numruns - 1))
-done
+./doRunTests.sh "$@"

--- a/test/run-ethercatmc-ioc.sh
+++ b/test/run-ethercatmc-ioc.sh
@@ -24,8 +24,26 @@ fi
 export EPICS_EEE_E3
 echo EPICS_EEE_E3=$EPICS_EEE_E3
 
-if test -z "$EPICS_BASE";then
-  echo >&2 "EPICS_BASE" is not set
+if test -z "$EPICS_HOST_ARCH"; then
+  RELEASELOCAL=../configure/RELEASE.local
+  if test -r "$RELEASELOCAL"; then
+    # Code stolen from .ci/travis/prepare.sh
+    eval $(grep "EPICS_BASE=" $RELEASELOCAL)
+    export EPICS_BASE
+    echo "EPICS_BASE=$EPICS_BASE"
+    if test -z "$EPICS_BASE"; then
+      echo >&2 "EPICS_BASE" is not set
+      exit 1
+    fi
+    [ -z "$EPICS_HOST_ARCH" -a -f $EPICS_BASE/src/tools/EpicsHostArch.pl ] && EPICS_HOST_ARCH=$(perl $EPICS_BASE/src/tools/EpicsHostArch.pl)
+    [ -z "$EPICS_HOST_ARCH" -a -f $EPICS_BASE/startup/EpicsHostArch.pl ] && EPICS_HOST_ARCH=$(perl $EPICS_BASE/startup/EpicsHostArch.pl)
+    export EPICS_HOST_ARCH
+    echo "EPICS_HOST_ARCH=$EPICS_HOST_ARCH"
+  fi
+fi
+
+if test -z "$EPICS_HOST_ARCH"; then
+  echo >&2 "EPICS_HOST_ARCH" is not set
   exit 1
 fi
 

--- a/test/test-ioc-with-sim.sh
+++ b/test/test-ioc-with-sim.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -x
+
+if ! type nc; then
+  echo >&2 "`nc` is not found"
+  exit 1
+fi
+
+killExitIocSimulator()
+{
+  # exit IOC
+  echo "exit" | nc localhost ${IOC_NC_PORT} || :
+  # terminate simulator
+  echo "kill" | nc localhost ${SIM_NC_PORT} || :
+}
+
+killExitIocSimulator
+echo env
+env
+echo =====
+echo set
+set
+echo =====
+SIM_NC_PORT=5000
+IOC_NC_PORT=5001
+
+# start simulator
+./run-ethercatmc-simulator.sh &
+sleep 3
+
+# start ioc
+nc -l  ${IOC_NC_PORT} | /bin/sh -e -x ./run-ethercatmc-ioc.sh  SolAxis-SimCfgDbg &
+sleep 3
+
+# run test cases
+/bin/sh -e -x ./run-ethercatmc-tests.sh IOC:m1
+status=$?
+
+killExitIocSimulator
+
+exit $status

--- a/test/test-pytest-pyepics-p4p.sh
+++ b/test/test-pytest-pyepics-p4p.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -x
+
+checkPythonPackage()
+{
+  IMPORTNAME=$1
+  python -c "import $IMPORTNAME"
+}
+
+printVersionIfPossible()
+{
+  PROGRAM=$1
+  if type "$PROGRAM"; then
+    "$PROGRAM" --version || :
+  fi
+}
+
+printVersionIfPossible python
+printVersionIfPossible python2
+printVersionIfPossible python3
+printVersionIfPossible pip
+printVersionIfPossible pip3
+printVersionIfPossible pytest
+
+
+checkPythonPackage pytest &&
+checkPythonPackage epics &&
+checkPythonPackage p4p


### PR DESCRIPTION
Continous integration: Make it possible to run the test suite under travis.
This commit sums up the following improvements:

test: Add Makefile and test-ioc-with-sim.sh
  Add a Makefile under test/
  make -C test test-ioc-with-sim
  will call the shell script "test-ioc-with-sim.sh"

run-ethercatmc-ioc.sh: get EPICS_HOST_ARCH out of RELEASE.local (if possible)
  The script assumes that EPICS_HOST_ARCH is set as an environment variable
  If not, look into configure/RELEASE.local to find out where EPICS_BASE is,
  and the call the EpicsHostArch.pl script provided by EPICS base

Add test-ioc-with-sim.sh
  Make it possible to start the simulator, an EPICS IOC and run the
  test suite

test/runTests.sh: Jump over conda/virtualenv if pytest can be executed
  The installation of pytest and friends is still not ideal,
  so jump over all this if we can execute pytest (as done on travis)

.travis.yml: Make -C test test-ioc-with-sim
  The test must be executed from test/ directory

test: Add install-mini-conda.sh (not yet used)

test: Break out pyTests/doRunTests.sh
  Slight refactor:
  Break csome code out from pyTests/runTests.sh into pyTests/doRunTests.sh
  This is a first step to seperate two different functionalities:
  - Prepare python, pytest and all the needed libs including
    the set up of environment variables.
    Either we can use VIRTUALENV, or CONDA or run "pytest" directly.
    This is dependent on the OS (MacOS, Debian/Ubuntu, centos) and the
    python version of the day (python 2 is to be phased out soonish)
  - Run the actual test suite (or single tests)