### PR TITLE
pytest36: moveIntoLimitSwitchFromTestCase()

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -38,14 +38,6 @@ jobs:
         # Job names also name artifacts, character limitations apply
         include:
 
-          - os: ubuntu-20.04
-            cmp: gcc
-            configuration: static
-            base: "3.15"
-            set: oldestset
-            checkws: true
-            name: "3.15 oldest static"
-
           - os: ubuntu-22.04
             cmp: gcc
             configuration: default

--- a/test/pytests36/122_Ethercat-JOGF_HLS.py
+++ b/test/pytests36/122_Ethercat-JOGF_HLS.py
@@ -41,34 +41,34 @@ class Test(unittest.TestCase):
     # high limit switch
     def test_TC_1222(self):
         tc_no = tc_no_base + 2
-        self.axisMr.moveIntoLimitSwitchFromTestCase(
+        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no, direction=direction, movingMethod="JOG"
-        )
+        ) is True
 
     # high limit switch via DVAL
     def test_TC_1223(self):
         tc_no = tc_no_base + 3
-        self.axisMr.moveIntoLimitSwitchFromTestCase(
+        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no, movingMethod="DVAL", setDLYfield=1.0
-        )
+        ) is True
 
     # high limit switch via moveVel
     # had been started
     def test_TC_1224(self):
         tc_no = tc_no_base + 4
-        self.axisMr.moveIntoLimitSwitchFromTestCase(
+        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no, direction=direction, movingMethod="MoveVel"
-        )
+        ) is True
 
     # low limit switch via moveVel and "infinite" Soft limit
     def test_TC_1225(self):
         tc_no = tc_no_base + 5
-        self.axisMr.moveIntoLimitSwitchFromTestCase(
+        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no,
             movingMethod="MoveVel",
             doDisableSoftLimit=False,
             setInfiniteSoftLimit=True,
-        )
+        ) is True
 
     def teardown_class(self):
         tc_no = int(filnam) * 10000 + 9999

--- a/test/pytests36/122_Ethercat-JOGF_HLS.py
+++ b/test/pytests36/122_Ethercat-JOGF_HLS.py
@@ -19,32 +19,6 @@ def lineno():
     return inspect.currentframe().f_back.f_lineno
 
 
-def moveIntoLimitSwitch(
-    self,
-    tc_no,
-    movingMethod="",
-    paramWhileMove=False,
-    doDisableSoftLimit=True,
-    setInfiniteSoftLimit=False,
-):
-    msta = int(self.axisCom.get(".MSTA"))
-    if msta & self.axisMr.MSTA_BIT_HOMED:
-        self.axisCom.putDbgStrToLOG("Start " + str(int(tc_no)), wait=True)
-        passed = self.axisMr.moveIntoLS(
-            tc_no=tc_no,
-            direction=direction,
-            movingMethod=movingMethod,
-            paramWhileMove=paramWhileMove,
-            doDisableSoftLimit=doDisableSoftLimit,
-            setInfiniteSoftLimit=setInfiniteSoftLimit,
-        )
-        if passed:
-            self.axisCom.putDbgStrToLOG("Passed " + str(tc_no), wait=True)
-        else:
-            self.axisCom.putDbgStrToLOG("Failed " + str(tc_no), wait=True)
-        assert passed
-
-
 class Test(unittest.TestCase):
     url_string = os.getenv("TESTEDMOTORAXIS")
     print(
@@ -67,25 +41,29 @@ class Test(unittest.TestCase):
     # high limit switch
     def test_TC_1222(self):
         tc_no = tc_no_base + 2
-        moveIntoLimitSwitch(self, tc_no, movingMethod="JOG")
+        self.axisMr.moveIntoLimitSwitchFromTestCase(
+            tc_no, direction=direction, movingMethod="JOG"
+        )
 
-    # high limit switch, disabling softlimts after the JOG
-    # had been started. This is not supported by our MCU SW
-    # def test_TC_1223(self):
-    #    tc_no = tc_no_base + 3
-    #    moveIntoLimitSwitch(self, tc_no, movingMethod="JOG", paramWhileMove=True)
+    # high limit switch via DVAL
+    def test_TC_1223(self):
+        tc_no = tc_no_base + 3
+        self.axisMr.moveIntoLimitSwitchFromTestCase(
+            tc_no, movingMethod="DVAL", setDLYfield=1.0
+        )
 
     # high limit switch via moveVel
     # had been started
     def test_TC_1224(self):
         tc_no = tc_no_base + 4
-        moveIntoLimitSwitch(self, tc_no, movingMethod="MoveVel")
+        self.axisMr.moveIntoLimitSwitchFromTestCase(
+            tc_no, direction=direction, movingMethod="MoveVel"
+        )
 
     # low limit switch via moveVel and "infinite" Soft limit
     def test_TC_1225(self):
         tc_no = tc_no_base + 5
-        moveIntoLimitSwitch(
-            self,
+        self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no,
             movingMethod="MoveVel",
             doDisableSoftLimit=False,

--- a/test/pytests36/132_Ethercat-JOGR_LLS.py
+++ b/test/pytests36/132_Ethercat-JOGR_LLS.py
@@ -41,33 +41,33 @@ class Test(unittest.TestCase):
     # low limit switch
     def test_TC_1322(self):
         tc_no = tc_no_base + 2
-        self.axisMr.moveIntoLimitSwitchFromTestCase(
+        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no, direction=direction, movingMethod="JOG"
-        )
+        ) is True
 
     # low limit switch via DVAL
     def test_TC_1323(self):
         tc_no = tc_no_base + 3
-        self.axisMr.moveIntoLimitSwitchFromTestCase(
+        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no, movingMethod="DVAL", setDLYfield=1.0
-        )
+        ) is True
 
     # low limit switch via moveVel
     def test_TC_1324(self):
         tc_no = tc_no_base + 4
-        self.axisMr.moveIntoLimitSwitchFromTestCase(
+        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no, direction=direction, movingMethod="MoveVel"
-        )
+        ) is True
 
     # low limit switch via moveVel and "infinite" Soft limit
     def test_TC_1325(self):
         tc_no = tc_no_base + 5
-        self.axisMr.moveIntoLimitSwitchFromTestCase(
+        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no,
             movingMethod="MoveVel",
             doDisableSoftLimit=False,
             setInfiniteSoftLimit=True,
-        )
+        ) is True
 
     def teardown_class(self):
         tc_no = int(filnam) * 10000 + 9999

--- a/test/pytests36/132_Ethercat-JOGR_LLS.py
+++ b/test/pytests36/132_Ethercat-JOGR_LLS.py
@@ -12,37 +12,11 @@ filnam = os.path.basename(__file__)[0:3]
 tc_no_base = int(os.path.basename(__file__)[0:3]) * 10
 ###
 
-direction = 0
+direction = -1
 
 
 def lineno():
     return inspect.currentframe().f_back.f_lineno
-
-
-def moveIntoLimitSwitch(
-    self,
-    tc_no,
-    movingMethod="",
-    paramWhileMove=False,
-    doDisableSoftLimit=True,
-    setInfiniteSoftLimit=False,
-):
-    msta = int(self.axisCom.get(".MSTA"))
-    if msta & self.axisMr.MSTA_BIT_HOMED:
-        self.axisCom.putDbgStrToLOG("Start " + str(int(tc_no)), wait=True)
-        passed = self.axisMr.moveIntoLS(
-            tc_no=tc_no,
-            direction=direction,
-            movingMethod=movingMethod,
-            paramWhileMove=paramWhileMove,
-            doDisableSoftLimit=doDisableSoftLimit,
-            setInfiniteSoftLimit=setInfiniteSoftLimit,
-        )
-        if passed:
-            self.axisCom.putDbgStrToLOG("Passed " + str(tc_no), wait=True)
-        else:
-            self.axisCom.putDbgStrToLOG("Failed " + str(tc_no), wait=True)
-        assert passed
 
 
 class Test(unittest.TestCase):
@@ -67,24 +41,28 @@ class Test(unittest.TestCase):
     # low limit switch
     def test_TC_1322(self):
         tc_no = tc_no_base + 2
-        moveIntoLimitSwitch(self, tc_no, movingMethod="JOG")
+        self.axisMr.moveIntoLimitSwitchFromTestCase(
+            tc_no, direction=direction, movingMethod="JOG"
+        )
 
-    # low limit switch, disabling softlimts after the JOG
-    # had been started. This is not supported by our MCU SW
-    # def test_TC_1323(self):
-    #    tc_no = tc_no_base + 3
-    #    moveIntoLimitSwitch(self, tc_no, movingMethod="JOG", paramWhileMove=True)
+    # low limit switch via DVAL
+    def test_TC_1323(self):
+        tc_no = tc_no_base + 3
+        self.axisMr.moveIntoLimitSwitchFromTestCase(
+            tc_no, movingMethod="DVAL", setDLYfield=1.0
+        )
 
     # low limit switch via moveVel
     def test_TC_1324(self):
         tc_no = tc_no_base + 4
-        moveIntoLimitSwitch(self, tc_no, movingMethod="MoveVel")
+        self.axisMr.moveIntoLimitSwitchFromTestCase(
+            tc_no, direction=direction, movingMethod="MoveVel"
+        )
 
     # low limit switch via moveVel and "infinite" Soft limit
     def test_TC_1325(self):
         tc_no = tc_no_base + 5
-        moveIntoLimitSwitch(
-            self,
+        self.axisMr.moveIntoLimitSwitchFromTestCase(
             tc_no,
             movingMethod="MoveVel",
             doDisableSoftLimit=False,

--- a/test/pytests36/AxisMr.py
+++ b/test/pytests36/AxisMr.py
@@ -573,8 +573,7 @@ class AxisMr:
         movingMethod="",
         doDisableSoftLimit=True,
         setInfiniteSoftLimit=False,
-        setDLYfield=None,
-        throw=True,
+        setDLYfield=None
     ):
         self.axisCom.putDbgStrToLOG("Start " + str(int(tc_no)), wait=True)
         self.powerOnHomeAxis(tc_no)
@@ -592,14 +591,9 @@ class AxisMr:
         if setDLYfield is not None:
             self.axisCom.put(".DLY", saved_DLY)
 
-        if throw:
-            if passed:
-                self.axisCom.putDbgStrToLOG("Passed " + str(tc_no), wait=True)
-            else:
-                self.axisCom.putDbgStrToLOG("Failed " + str(tc_no), wait=True)
-            assert passed
-        else:
-            return passed
+        passed_str = "Passed " if passed is True else "Failed "
+        self.axisCom.putDbgStrToLOG(passed_str + str(tc_no), wait=True)
+        return passed
 
     # move into limit switch
     # We need different combinations (WIP)
@@ -617,8 +611,11 @@ class AxisMr:
         setInfiniteSoftLimit=False,
         movingMethod="JOG",
     ):
-        assert tc_no != 0
-        assert direction != 0
+        if tc_no < 0:
+            raise ValueError(f"Expected tc_no to be greater than 0, but got {tc_no}")
+        if not direction in {-1, 1}:
+            raise ValueError(f"Expected 1 or -1, but got {direction}")
+
         old_VELO = self.axisCom.get(".VELO")
         vmax = self.axisCom.get(".VMAX")
         if vmax == 0.0:

--- a/test/pytests36/AxisMr.py
+++ b/test/pytests36/AxisMr.py
@@ -566,6 +566,41 @@ class AxisMr:
         self.axisCom.putDbgStrToLOG(debug_text, wait=True)
         self.motorInitAllForBDST(tc_no)
 
+    def moveIntoLimitSwitchFromTestCase(
+        self,
+        tc_no,
+        direction=0,
+        movingMethod="",
+        doDisableSoftLimit=True,
+        setInfiniteSoftLimit=False,
+        setDLYfield=None,
+        throw=True,
+    ):
+        self.axisCom.putDbgStrToLOG("Start " + str(int(tc_no)), wait=True)
+        self.powerOnHomeAxis(tc_no)
+        self.setSoftLimitsOn(tc_no, initAbsMinMax=True)
+        if setDLYfield is not None:
+            saved_DLY = self.axisCom.get(".DLY")
+            self.axisCom.put(".DLY", setDLYfield)
+        passed = self.moveIntoLS(
+            tc_no=tc_no,
+            direction=direction,
+            movingMethod=movingMethod,
+            doDisableSoftLimit=doDisableSoftLimit,
+            setInfiniteSoftLimit=setInfiniteSoftLimit,
+        )
+        if setDLYfield is not None:
+            self.axisCom.put(".DLY", saved_DLY)
+
+        if throw:
+            if passed:
+                self.axisCom.putDbgStrToLOG("Passed " + str(tc_no), wait=True)
+            else:
+                self.axisCom.putDbgStrToLOG("Failed " + str(tc_no), wait=True)
+            assert passed
+        else:
+            return passed
+
     # move into limit switch
     # We need different combinations (WIP)
     # - The direction (hit HLS or LLS)
@@ -577,14 +612,13 @@ class AxisMr:
     def moveIntoLS(
         self,
         tc_no=0,
-        direction=-1,
+        direction=0,
         doDisableSoftLimit=True,
         setInfiniteSoftLimit=False,
         movingMethod="JOG",
-        paramWhileMove=False,
     ):
         assert tc_no != 0
-        assert direction >= 0
+        assert direction != 0
         old_VELO = self.axisCom.get(".VELO")
         vmax = self.axisCom.get(".VMAX")
         if vmax == 0.0:
@@ -599,11 +633,9 @@ class AxisMr:
         old_DHLM = self.axisCom.get("-CfgDHLM")
         old_DLLM = self.axisCom.get("-CfgDLLM")
         margin = 1.1
-        if paramWhileMove:
-            margin = margin + 2
         if movingMethod == "MoveVel":
             movingFieldName = "-MoveVel"
-        if direction > 0:
+        if direction == 1:
             softlimitFieldName = "-CfgDHLM"
             nearly_infinite = 999999.0
             soft_limit_pos = old_DHLM
@@ -615,7 +647,10 @@ class AxisMr:
                 movingFieldValue = 1
             elif movingMethod == "MoveVel":
                 movingFieldValue = jvel
-        else:
+            elif movingMethod == "DVAL":
+                movingFieldName = ".DVAL"
+                movingFieldValue = nearly_infinite
+        elif direction == -1:
             softlimitFieldName = "-CfgDLLM"
             nearly_infinite = -999999.0
             soft_limit_pos = old_DLLM
@@ -629,9 +664,17 @@ class AxisMr:
                 movingFieldValue = 0 - jvel
             elif movingMethod == "MoveAbs":
                 movingFieldValue = 0 - jvel
+            elif movingMethod == "DVAL":
+                movingFieldName = ".DVAL"
+                movingFieldValue = nearly_infinite
+        else:
+            print(
+                f"{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {filnam} {tc_no} illegal direction={direction}"
+            )
+            return False
 
         print(
-            f"{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {filnam} {tc_no} paramWhileMove={paramWhileMove} margin={margin}"
+            f"{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {filnam} {tc_no} margin={margin}"
         )
         print(
             f"{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {filnam} {tc_no} direction={direction } jog_start_pos={jog_start_pos:f}"
@@ -647,33 +690,10 @@ class AxisMr:
             movingFieldValue = nearly_infinite
 
         if doDisableSoftLimit:
-            if paramWhileMove:
-                # Start jogging, switch soft limit off while jogging
-                #
-                wait_for_stop = self.jogCalcTimeout(tc_no, direction)
-                self.axisCom.put(movingFieldName, movingFieldValue)
-                wait_for_start = 2
-                self.waitForStart(tc_no, wait_for_start)
-                self.setSoftLimitsOff(tc_no, direction=direction)
-                try:
-                    self.waitForStop(tc_no, wait_for_stop)
-                except Exception:
-                    self.axisCom.put(".STOP", 1)
-                    try:
-                        self.waitForStop(tc_no, 2.0)
-                    except Exception as ex:
-                        print(
-                            f"{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {filnam} {tc_no} ex={ex}"
-                        )
-                if direction > 0:
-                    self.axisCom.put(".JOGF", 0)
-                else:
-                    self.axisCom.put(".JOGR", 0)
-            else:
-                self.setSoftLimitsOff(tc_no, direction=direction)
-                time_to_wait = self.jogCalcTimeout(tc_no, direction)
-                self.axisCom.put(movingFieldName, movingFieldValue)
-                self.waitForStartAndDone(str(tc_no), 30 + time_to_wait + 3.0)
+            self.setSoftLimitsOff(tc_no, direction=direction)
+            time_to_wait = self.jogCalcTimeout(tc_no, direction)
+            self.axisCom.put(movingFieldName, movingFieldValue)
+            self.waitForStartAndDone(str(tc_no), 30 + time_to_wait + 3.0)
         else:
             if setInfiniteSoftLimit:
                 oldSoftLimitValue = self.axisCom.get(softlimitFieldName)
@@ -838,7 +858,7 @@ class AxisMr:
 
     def setCNENandWait(self, tc_no, cnen):
         wait_for_power_changed = 6.0
-        # capv_self.axisMr.capvput(
+        # capv_self.capvput(
         #     + "-DbgStrToLOG", "CNEN=" + str(cnen) + " " + tc_no[0:20], wait=True
         # )
         self.axisCom.put(".CNEN", cnen)


### PR DESCRIPTION
Factor out common code from test case 122 and 132 into AxisMr and introduce moveIntoLimitSwitchFromTestCase()

- Make it possible to do more prepartions and tweaks: Add throw=True which is the old behaviour to assert at the end of the test case. New test cases may need to run other code, allow them to use the return value and assert on their own needs.
- Remove paramWhileMove from moveIntoLimitSwitch() Origianally trying to test if a parameter can be changed while moving, this test had been commented out since a long time. Remove the optional parameter that had not been used: paramWhileMove
- Improve the handling here: Instead of silently jumping over the test: home the motor and set soft limits
- Make it possible to use the DLY functionality in the motorRecord and test it.
- Unify the direction: use -1 for backward, +1 for forward and 0 for undefined. Changes to be committed:
    modified:   pytests36/122_Ethercat-JOGF_HLS.py
    modified:   pytests36/132_Ethercat-JOGR_LLS.py
    modified:   pytests36/AxisMr.py