### PR TITLE
pytest36: Fix comments from black and ruff

### DIFF
--- a/test/pytests36/122_Ethercat-JOGF_HLS.py
+++ b/test/pytests36/122_Ethercat-JOGF_HLS.py
@@ -41,34 +41,46 @@ class Test(unittest.TestCase):
     # high limit switch
     def test_TC_1222(self):
         tc_no = tc_no_base + 2
-        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
-            tc_no, direction=direction, movingMethod="JOG"
-        ) is True
+        assert (
+            self.axisMr.moveIntoLimitSwitchFromTestCase(
+                tc_no, direction=direction, movingMethod="JOG"
+            )
+            is True
+        )
 
     # high limit switch via DVAL
     def test_TC_1223(self):
         tc_no = tc_no_base + 3
-        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
-            tc_no, movingMethod="DVAL", setDLYfield=1.0
-        ) is True
+        assert (
+            self.axisMr.moveIntoLimitSwitchFromTestCase(
+                tc_no, movingMethod="DVAL", setDLYfield=1.0
+            )
+            is True
+        )
 
     # high limit switch via moveVel
     # had been started
     def test_TC_1224(self):
         tc_no = tc_no_base + 4
-        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
-            tc_no, direction=direction, movingMethod="MoveVel"
-        ) is True
+        assert (
+            self.axisMr.moveIntoLimitSwitchFromTestCase(
+                tc_no, direction=direction, movingMethod="MoveVel"
+            )
+            is True
+        )
 
     # low limit switch via moveVel and "infinite" Soft limit
     def test_TC_1225(self):
         tc_no = tc_no_base + 5
-        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
-            tc_no,
-            movingMethod="MoveVel",
-            doDisableSoftLimit=False,
-            setInfiniteSoftLimit=True,
-        ) is True
+        assert (
+            self.axisMr.moveIntoLimitSwitchFromTestCase(
+                tc_no,
+                movingMethod="MoveVel",
+                doDisableSoftLimit=False,
+                setInfiniteSoftLimit=True,
+            )
+            is True
+        )
 
     def teardown_class(self):
         tc_no = int(filnam) * 10000 + 9999

--- a/test/pytests36/132_Ethercat-JOGR_LLS.py
+++ b/test/pytests36/132_Ethercat-JOGR_LLS.py
@@ -41,33 +41,45 @@ class Test(unittest.TestCase):
     # low limit switch
     def test_TC_1322(self):
         tc_no = tc_no_base + 2
-        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
-            tc_no, direction=direction, movingMethod="JOG"
-        ) is True
+        assert (
+            self.axisMr.moveIntoLimitSwitchFromTestCase(
+                tc_no, direction=direction, movingMethod="JOG"
+            )
+            is True
+        )
 
     # low limit switch via DVAL
     def test_TC_1323(self):
         tc_no = tc_no_base + 3
-        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
-            tc_no, movingMethod="DVAL", setDLYfield=1.0
-        ) is True
+        assert (
+            self.axisMr.moveIntoLimitSwitchFromTestCase(
+                tc_no, movingMethod="DVAL", setDLYfield=1.0
+            )
+            is True
+        )
 
     # low limit switch via moveVel
     def test_TC_1324(self):
         tc_no = tc_no_base + 4
-        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
-            tc_no, direction=direction, movingMethod="MoveVel"
-        ) is True
+        assert (
+            self.axisMr.moveIntoLimitSwitchFromTestCase(
+                tc_no, direction=direction, movingMethod="MoveVel"
+            )
+            is True
+        )
 
     # low limit switch via moveVel and "infinite" Soft limit
     def test_TC_1325(self):
         tc_no = tc_no_base + 5
-        assert self.axisMr.moveIntoLimitSwitchFromTestCase(
-            tc_no,
-            movingMethod="MoveVel",
-            doDisableSoftLimit=False,
-            setInfiniteSoftLimit=True,
-        ) is True
+        assert (
+            self.axisMr.moveIntoLimitSwitchFromTestCase(
+                tc_no,
+                movingMethod="MoveVel",
+                doDisableSoftLimit=False,
+                setInfiniteSoftLimit=True,
+            )
+            is True
+        )
 
     def teardown_class(self):
         tc_no = int(filnam) * 10000 + 9999

--- a/test/pytests36/AxisMr.py
+++ b/test/pytests36/AxisMr.py
@@ -573,7 +573,7 @@ class AxisMr:
         movingMethod="",
         doDisableSoftLimit=True,
         setInfiniteSoftLimit=False,
-        setDLYfield=None
+        setDLYfield=None,
     ):
         self.axisCom.putDbgStrToLOG("Start " + str(int(tc_no)), wait=True)
         self.powerOnHomeAxis(tc_no)
@@ -613,7 +613,7 @@ class AxisMr:
     ):
         if tc_no < 0:
             raise ValueError(f"Expected tc_no to be greater than 0, but got {tc_no}")
-        if not direction in {-1, 1}:
+        if direction not in {-1, 1}:
             raise ValueError(f"Expected 1 or -1, but got {direction}")
 
         old_VELO = self.axisCom.get(".VELO")


### PR DESCRIPTION
As you may (not) know, there are 2 different ci actions: github and gitlab.
Both are testing different things, and so far no one had been able to integrate the gitlab stuff into github.

The last changes did not pass the gitlab pipeline. Fix this.

Changes to be committed:
    modified:   pytests36/122_Ethercat-JOGF_HLS.py
    modified:   pytests36/132_Ethercat-JOGR_LLS.py
    modified:   pytests36/AxisMr.py