### PR TITLE
ethercatmcController.h: Proper locking of the serial port

### DIFF
--- a/ethercatmcApp/src/ethercatmcController.h
+++ b/ethercatmcApp/src/ethercatmcController.h
@@ -592,23 +592,36 @@ class epicsShareClass ethercatmcController : public asynMotorController {
     int ethercatmcErrTxt_;
   } defAsynPara;
 
-#define EMC_ENTER_ADS_CHECK_LOCK(LINENO)                  \
-  do {                                                    \
-    if (ctrlLocal.lockADSlineno) {                        \
-      asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,    \
-                "%s lockADSlineno=%d\n", "ethercatmcADS", \
-                ctrlLocal.lockADSlineno);                 \
-    }                                                     \
-    ctrlLocal.lockADSlineno = LINENO;                     \
+#define EMC_ENTER_ADS_CHECK_LOCK(LINENO)                                     \
+  do {                                                                       \
+    asynStatus lockStatus;                                                   \
+    lockStatus = pasynManager->queueLockPort(pasynUser);                     \
+    if (lockStatus != asynSuccess) {                                         \
+      asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s lockStatus=%d\n", \
+                "ethercatmcADS", (int)lockStatus);                           \
+      return lockStatus;                                                     \
+    }                                                                        \
+    if (ctrlLocal.lockADSlineno) {                                           \
+      asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,                       \
+                "%s lockADSlineno=%d\n", "ethercatmcADS",                    \
+                ctrlLocal.lockADSlineno);                                    \
+    }                                                                        \
+    ctrlLocal.lockADSlineno = LINENO;                                        \
   } while (0)
 
-#define EMC_LEAVE_ADS_CHECK_LOCK(LINENO)                           \
-  do {                                                             \
-    if (!ctrlLocal.lockADSlineno) {                                \
-      asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,             \
-                "%s lockADSlineno=%d\n", "ethercatmcADS", LINENO); \
-    }                                                              \
-    ctrlLocal.lockADSlineno = 0;                                   \
+#define EMC_LEAVE_ADS_CHECK_LOCK(LINENO)                                       \
+  do {                                                                         \
+    asynStatus unlockStatus;                                                   \
+    unlockStatus = pasynManager->queueUnlockPort(pasynUser);                   \
+    if (unlockStatus != asynSuccess) {                                         \
+      asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s unlockStatus=%d\n", \
+                "ethercatmcADS", (int)unlockStatus);                           \
+    }                                                                          \
+    if (!ctrlLocal.lockADSlineno) {                                            \
+      asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,                         \
+                "%s lockADSlineno=%d\n", "ethercatmcADS", LINENO);             \
+    }                                                                          \
+    ctrlLocal.lockADSlineno = 0;                                               \
   } while (0)
 
   friend class ethercatmcIndexerAxis;


### PR DESCRIPTION
Fix a long standing design-miss:
While debugging another issue it turned out that the calls to queueLockPort() and queueUnlockPort() had been missing when an ADS transaction is made.
The code should go like this:
- queueLockPort()
- send request
- read first part of response (AMS header) Now we have the length of the response
 - read second part of response (if any)
- queueUnockPort()

That had been not a problem so far, because only one asnyport ("MCU1") is using the communication asyn port ("MC_CPU1") and locking of "MCU1" is enough.
However, locking of the communication channel is the correct thing to do.