### PR TITLE
op/Boy: Fix to open the Cabinet OPI

### DIFF
--- a/ethercatmcExApp/op/Boy/motor-0-ptp.opi
+++ b/ethercatmcExApp/op/Boy/motor-0-ptp.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-1-pils-ptp-Max-Red-Current-para195-197.opi
+++ b/ethercatmcExApp/op/Boy/motor-1-pils-ptp-Max-Red-Current-para195-197.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-1-pils.opi
+++ b/ethercatmcExApp/op/Boy/motor-1-pils.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-1-ptp.opi
+++ b/ethercatmcExApp/op/Boy/motor-1-ptp.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-2-pils.opi
+++ b/ethercatmcExApp/op/Boy/motor-2-pils.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-3-pils.opi
+++ b/ethercatmcExApp/op/Boy/motor-3-pils.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-3-ptp.opi
+++ b/ethercatmcExApp/op/Boy/motor-3-ptp.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-4-pils.opi
+++ b/ethercatmcExApp/op/Boy/motor-4-pils.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-4-ptp.opi
+++ b/ethercatmcExApp/op/Boy/motor-4-ptp.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-4x2-pils.opi
+++ b/ethercatmcExApp/op/Boy/motor-4x2-pils.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-4x4-temp.opi
+++ b/ethercatmcExApp/op/Boy/motor-4x4-temp.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-4x4.opi
+++ b/ethercatmcExApp/op/Boy/motor-4x4.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-5-pils.opi
+++ b/ethercatmcExApp/op/Boy/motor-5-pils.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-6-pils.opi
+++ b/ethercatmcExApp/op/Boy/motor-6-pils.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-estiaSel1-temp.opi
+++ b/ethercatmcExApp/op/Boy/motor-estiaSel1-temp.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-estiaSel2-temp.opi
+++ b/ethercatmcExApp/op/Boy/motor-estiaSel2-temp.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-ymir-mcs1-pils.opi
+++ b/ethercatmcExApp/op/Boy/motor-ymir-mcs1-pils.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/motor-ymir-mcs2-pils.opi
+++ b/ethercatmcExApp/op/Boy/motor-ymir-mcs2-pils.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/shutter-1.opi
+++ b/ethercatmcExApp/op/Boy/shutter-1.opi
@@ -125,11 +125,9 @@ $(pv_value)</tooltip>
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>

--- a/ethercatmcExApp/op/Boy/tools/Cabinet.mid
+++ b/ethercatmcExApp/op/Boy/tools/Cabinet.mid
@@ -41,11 +41,9 @@
       <path>ethercatmcCabinet.opi</path>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <P>$(P)</P>
-        <R>Cabinet-</R>
       </macros>
       <replace>0</replace>
-      <description>$(P) (Cabinet)</description>
+      <description>$(PREFIX)Cabinet</description>
     </action>
   </actions>
   <y>0</y>


### PR DESCRIPTION
Need to seperate $(P) from $(PREFIX) in the opi files: The PV is always $(PREFIX)Cabinet

Addjust Cabinet.mid and re-generate all opis that need updates.