### PR TITLE
ethercatmcADS.cpp: fix memory leak in setMemIdxGrpIdxOffFL, fix #13

### DIFF
--- a/ethercatmcApp/src/ethercatmcADS.cpp
+++ b/ethercatmcApp/src/ethercatmcADS.cpp
@@ -629,6 +629,7 @@ asynStatus ethercatmcController::setMemIdxGrpIdxOffFL(
       status = asynError;
     }
   }
+  free(p_write_buf);
   return status;
 }
 #endif


### PR DESCRIPTION
See Issue #13 for details
This PR adds `free(p_write_buf);` to the referred method on issue above