### PR TITLE
ci/gha: Run black and ruff on python files

### DIFF
--- a/.github/workflows/ci-scripts-ruff.yml
+++ b/.github/workflows/ci-scripts-ruff.yml
@@ -1,0 +1,9 @@
+name: ruff
+on:
+  push:
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3

--- a/.github/workflows/ci-scripts-shfmt.yml
+++ b/.github/workflows/ci-scripts-shfmt.yml
@@ -1,0 +1,12 @@
+name: shfmt
+on:
+  push:
+jobs:
+    shfmt:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - uses: mfinelli/setup-shfmt@v3
+          with:
+            shfmt-version: 3.3.1
+        - run: shfmt -i 2 -ci -d *.sh ethercatmcExApp/op/Boy/tools/*.sh test/*.sh test/pytests36/*.sh test/pythonscripts/*.sh

--- a/install-run-black.sh
+++ b/install-run-black.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+#Check black, the python formatter
+BLACK_VERSION=23.9.1
+if ! black --version | grep -q "[^0-9]${BLACK_VERSION}[^0-9]"; then
+  pip install git+https://github.com/psf/black@$BLACK_VERSION
+fi
+if ! black --version | grep -q "[^0-9]${BLACK_VERSION}[^0-9]"; then
+  echo >&2 black not found or wrong version
+  exit 1
+fi
+# shellcheck disable=SC2035
+TERM=dumb black test/pytests36/*.py test/pythonscripts/*.py

--- a/test/pythonscripts/msta2string.py
+++ b/test/pythonscripts/msta2string.py
@@ -1,28 +1,24 @@
 #!/usr/bin/env python3
 
+# If you ever wondered, what this (shortened) line means
+# ... [motorRecord.cc:1815 Mtr 00] motor is stopped ... msta=0x6966
+#                                                      ^^^^^^^^^^^
+# this script is for you:
+# ... motor is stopped msta=0x6966(LLS SlipStall HLS)
 
-'''
-If you ever wondered, what this (shortened) line means
-... [motorRecord.cc:1815 Mtr 00] motor is stopped ... msta=0x6966
-                                                      ^^^^^^^^^^^
-this script is for you:
-... motor is stopped msta=0x6966(LLS SlipStall HLS)
+# You can either run
+# a) camonitor/pvmonitor IOC:m1.MSTA | python msta2string.py
+# b) python msta2string.py <ioclog.txt
+# c) tail -f ioclog.txt | python msta2string.py
 
-You can either run
-a) camonitor/pvmonitor IOC:m1.MSTA | python msta2string.py
-b) python msta2string.py <ioclog.txt
-c) tail -f ioclog.txt | python msta2string.py
-
-Depending on your OS version, python must be written as python3
-on modern systems the word python may be ommited
+# Depending on your OS version, python must be written as python3
+# on modern systems the word python may be ommited
 
 
-
-The prefix in front of the line helps to debug if
-the regular expressions bite:
-"o:" means old, "m:" means motor, "s:" means stop
-"L:" is a "normal" line
-'''
+# The prefix in front of the line helps to debug if
+# the regular expressions bite:
+# "o:" means old, "m:" means motor, "s:" means stop
+# "L:" is a "normal" line
 
 import re
 import sys


### PR DESCRIPTION
Add black and ruff to github (same as on gitlab, kind of) Need to change the multi-string comment in msta2string.py because there seems to be different opinions in the tools: Some think that this should be at the beginning,
some think that ''' should be used, others vote for """ To skip this useless discussions, use the classic '#' sign

Changes to be committed:
    modified:   .github/workflows/ci-scripts-build.yml
    new file:   .github/workflows/ci-scripts-ruff.yml
    new file:   install-run-black.sh
    modified:   test/pythonscripts/msta2string.py