### PR TITLE
ethercatmcCabinet.template: remove hardcoded parameter name

### DIFF
--- a/ethercatmcApp/Db/ethercatmcCabinet.template
+++ b/ethercatmcApp/Db/ethercatmcCabinet.template
@@ -72,12 +72,6 @@ record(stringin, "$(P)$(R)BitNam10") {
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit10")
     field(SCAN, "I/O Intr")
 }
-record(stringin, "$(P)$(R)BitNam10") {
-    field(DTYP, "asynOctetRead")
-    field(DESC, "Cabinet status bit 10 name")
-    field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit10")
-    field(SCAN, "I/O Intr")
-}
 record(stringin, "$(P)$(R)BitNam11") {
     field(DTYP, "asynOctetRead")
     field(DESC, "Cabinet status bit 11 name")

--- a/ethercatmcApp/Db/ethercatmcCabinet.template
+++ b/ethercatmcApp/Db/ethercatmcCabinet.template
@@ -1,133 +1,158 @@
 record(mbbiDirect, "$(P)$(R)")
 {
     field(DTYP, "asynUInt32Digital")
-    field(DESC, "Cabinet")
-    field(INP,  "@asynMask($(MOTOR_PORT),0 0x3FFFFFF)Cabinet")
+    field(DESC, "Cabinet 32 bit status")
+    field(INP,  "@asynMask($(MOTOR_PORT),0 0x3FFFFFF)$(R)")
     field(SCAN, "I/O Intr")
 }
 
 record(stringin, "$(P)$(R)BitNam0") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 0 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit0")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam1") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 1 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit1")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam2") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 2 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit2")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam3") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 3 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit3")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam4") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 4 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit4")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam5") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 5 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit5")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam6") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 6 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit6")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam7") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 7 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit7")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam8") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 8 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit8")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam9") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 9 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit9")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam10") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 10 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit10")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam10") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 10 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit10")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam11") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 11 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit11")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam12") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 12 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit12")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam13") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 13 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit13")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam14") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 14 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit14")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam15") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 15 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit15")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam16") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 16 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit16")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam17") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 17 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit17")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam18") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 18 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit18")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam19") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 19 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit19")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam20") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 20 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit20")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam21") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 21 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit21")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam22") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 22 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit22")
     field(SCAN, "I/O Intr")
 }
 record(stringin, "$(P)$(R)BitNam23") {
     field(DTYP, "asynOctetRead")
+    field(DESC, "Cabinet status bit 23 name")
     field(INP,  "@asyn($(MOTOR_PORT),0)$(R)_NamBit23")
     field(SCAN, "I/O Intr")
 }


### PR DESCRIPTION
The PV that receives the 32 bit value of the cabinet status had "Cabinet" as hardcoded asyn parameter name, whereas the corresponding parameter creator in ethercatmcCabinet.iocsh loads its name as `$(R)`. This lead to the parameter not being found unless the user loads R as "Cabinet", therefore fix was needed. For consistency with the others, I substituted the hardcoded name for `$(R)`. Also, I added descriptions to the bits PVs, which adds extra information about their meaning. 

I also removed one duplicated PV.

This closes #15 and closes #21.