### PR TITLE
ethercatmcCabinet: hardcode cabinet paramName in template and iocsh

### DIFF
--- a/ethercatmcApp/Db/ethercatmcCabinet.template
+++ b/ethercatmcApp/Db/ethercatmcCabinet.template
@@ -2,7 +2,7 @@ record(mbbiDirect, "$(P)$(R)")
 {
     field(DTYP, "asynUInt32Digital")
     field(DESC, "Cabinet 32 bit status")
-    field(INP,  "@asynMask($(MOTOR_PORT),0 0x3FFFFFF)$(R)")
+    field(INP,  "@asynMask($(MOTOR_PORT),0 0x3FFFFFF)Cabinet")
     field(SCAN, "I/O Intr")
 }
 

--- a/iocsh/ethercatmcCabinet.iocsh
+++ b/iocsh/ethercatmcCabinet.iocsh
@@ -1,4 +1,4 @@
-ethercatmcCreateAsynParam $(MOTOR_PORT) $(R)          UInt32Digital
+ethercatmcCreateAsynParam $(MOTOR_PORT) Cabinet        UInt32Digital
 
 ethercatmcCreateAsynParam $(MOTOR_PORT) $(R)_NamBit0   Octet
 ethercatmcCreateAsynParam $(MOTOR_PORT) $(R)_NamBit1   Octet


### PR DESCRIPTION
In PR #22 the cabinet status asyn parameter name was changed to be defined by the macro $R, but this generates a problem because the PILS device for this is defined as "Cabinet#0", which imposes the parameter name to be "Cabinet". This commits hardcodes the parameter name properly, so that it cannot be user-defined.