### PR TITLE
ci-scripts-shellcheck.yml: Fix again

### DIFF
--- a/.github/workflows/ci-scripts-shellcheck.yml
+++ b/.github/workflows/ci-scripts-shellcheck.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: ludeeus/action-shellcheck@master
         with:
           version: v0.9.0
-      run: |
-          ./checkshellcheck.sh
+          ignore_paths: >-
+            ethercatmcExApp/op


### PR DESCRIPTION
Run shellcheck "as is" and ignore the directory
ethercatmcExApp/op

Note: Fixing the scripts here may be done one day in the future