### PR TITLE
ethercatmc.template: include power handling PVs

### DIFF
--- a/ethercatmcApp/Db/ethercatmc.template
+++ b/ethercatmcApp/Db/ethercatmc.template
@@ -434,3 +434,12 @@ record(longin,"$(P)$(R)-CnenVis") {
     field(INP,"@asyn($(MOTOR_PORT),$(AXIS_NO))MOTOR_STATUS_GAIN_SUPPORT")
     field(SCAN, "I/O Intr")
 }
+
+#Power handling
+record(longout, "$(P)$(R)-PwrAuto")
+{
+    field(DESC, "power automatic on")
+    field(DTYP, "asynInt32")
+    field(OUT,"@asyn($(MOTOR_PORT),$(AXIS_NO))MOTOR_POWER_AUTO_ONOFF")
+    info(asyn:READBACK,"1")
+}

--- a/ethercatmcApp/Db/ethercatmcdebug.template
+++ b/ethercatmcApp/Db/ethercatmcdebug.template
@@ -7,14 +7,6 @@ record(longout, "$(P)$(R)-PwrCNEN")
     info(asyn:READBACK,"1")
 }
 
-record(longout, "$(P)$(R)-PwrAuto")
-{
-    field(DESC, "power automatic on")
-    field(DTYP, "asynInt32")
-    field(OUT,"@asyn($(MOTOR_PORT),$(AXIS_NO))MOTOR_POWER_AUTO_ONOFF")
-    info(asyn:READBACK,"1")
-}
-
 record(ao, "$(P)$(R)-PwrOnDly")
 {
     field(DESC, "power on delay")


### PR DESCRIPTION
The referred PVs are loaded only in the ethercatmcdebug.template but are/might also be needed when in non-debug mode. This commit includes those PVs. Also, this closes #26.