### PR TITLE
Axis: Skip param readback in RESET

### DIFF
--- a/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
@@ -1068,16 +1068,20 @@ asynStatus ethercatmcIndexerAxis::doThePoll(bool cached, bool *moving) {
     pC_->setAlarmStatusSeverityWrapper(
         axisNo_, pC_->defAsynPara.ethercatmcRBV_TSE_, RBV_TSEstatus);
   }
-  /* Read back parameters. Do not do it in localMode */
-  if (!localMode && drvlocal.clean.iTypCode == 0x5010) {
-    pollReadBackParameters(idxAuxBits, paramCtrl, paramfValue);
-  }
-  if (drvlocal.clean.iTypCode == 0x5010 || drvlocal.clean.iTypCode == 0x1E04) {
-    if (!drvlocal.clean.hasPolledAllEnums) {
-      drvlocal.clean.hasPolledAllEnums = readEnumsAndValueAndCallbackIntoMbbi();
+  if (idxStatusCode != idxStatusCodeRESET && !localMode) {
+    /* Read back parameters. Do not do it in localMode.
+       Do not do it when axis stays in  reset */
+    if (drvlocal.clean.iTypCode == 0x5010) {
+      pollReadBackParameters(idxAuxBits, paramCtrl, paramfValue);
+      if (drvlocal.clean.iTypCode == 0x5010 ||
+          drvlocal.clean.iTypCode == 0x1E04) {
+        if (!drvlocal.clean.hasPolledAllEnums) {
+          drvlocal.clean.hasPolledAllEnums =
+              readEnumsAndValueAndCallbackIntoMbbi();
+        }
+      }
     }
   }
-
   if ((idxStatusCode != drvlocal.dirty.idxStatusCodeLog) ||
       (errorID != drvlocal.dirty.old_ErrorIdLog)) {
     if (errorID) {


### PR DESCRIPTION
One problem showed up during commissioning:
Some axes are "spare" and not used.
In the ideal world those where not at all in the PILS table, neither would there be an EPICS axis.
However, the hardware is there and they may be commissioned inside the MCU one day. And as things are today, they will work without any changes needed in EPICS.
The problem we found is, that the EPICS driver (this module) tries to read paramaters, while there is no code nor data structures inside the MCU to support this, leading to a spammy IOC log file, an example: ... poll(19) paramIndex=222 paramCtrl=STEPS_PER_REV (0xa0de)

To avoid this useless polling, do not do it when the axis is in RESET state.
Which is the case whenever it is not handled at all inside the MCU.