### PR TITLE
Clean up printing of changed reason bits

### DIFF
--- a/ethercatmcApp/src/ethercatmcController.cpp
+++ b/ethercatmcApp/src/ethercatmcController.cpp
@@ -333,14 +333,6 @@ ethercatmcController::ethercatmcController(const char *portName,
               &defAsynPara.ethercatmcNamAux22_);
   createParam(ethercatmcNamAux23_String, asynParamOctet,
               &defAsynPara.ethercatmcNamAux23_);
-  createParam(ethercatmcNamBit24_String, asynParamOctet,
-              &defAsynPara.ethercatmcNamBit24_);
-  createParam(ethercatmcNamBit25_String, asynParamOctet,
-              &defAsynPara.ethercatmcNamBit25_);
-  createParam(ethercatmcNamBit26_String, asynParamOctet,
-              &defAsynPara.ethercatmcNamBit26_);
-  createParam(ethercatmcNamBit27_String, asynParamOctet,
-              &defAsynPara.ethercatmcNamBit27_);
   createParam(ethercatmcPollScalingString, asynParamInt32,
               &defAsynPara.ethercatmcPollScaling_);
   createParam(ethercatmcCfgVELO_RBString, asynParamFloat64,

--- a/ethercatmcApp/src/ethercatmcController.h
+++ b/ethercatmcApp/src/ethercatmcController.h
@@ -26,8 +26,8 @@ FILENAME...   ethercatmcController.h
 #define ETHERCATMC_ASYN_ASYNPARAMINT64
 #endif
 
-#define MAX_AUX_BIT_SHOWN 24
-#define MAX_REASON_AUX_BIT_SHOW (MAX_AUX_BIT_SHOWN + 4)
+#define NUM_AUX_BITS 24
+#define MAX_REASON_AUX_BIT_SHOW (NUM_AUX_BITS + 4)
 
 #ifdef asynParamMetaMask
 #define ETHERCATMC_ASYN_PARAMMETA
@@ -73,10 +73,6 @@ FILENAME...   ethercatmcController.h
 #define ethercatmcNamAux21_String "NamAuxBit21"
 #define ethercatmcNamAux22_String "NamAuxBit22"
 #define ethercatmcNamAux23_String "NamAuxBit23"
-#define ethercatmcNamBit24_String "NamBit24"
-#define ethercatmcNamBit25_String "NamBit25"
-#define ethercatmcNamBit26_String "NamBit26"
-#define ethercatmcNamBit27_String "NamBit27"
 #define ethercatmcFoffVisString "FoffVis"
 #define ethercatmcHomeVisString "HomeVis"
 #define ethercatmcHomProc_RBString "HomProc-RB"
@@ -449,9 +445,9 @@ class epicsShareClass ethercatmcController : public asynMotorController {
   pilsAsynDevInfo_type *findIndexerOutputDevice(int axisNo, int function,
                                                 asynParamType myEPICSParamType);
 
-  void changedAuxBits_to_ASCII(int axisNo, int functionNamAux0,
-                               epicsUInt32 statusReasonAux,
-                               epicsUInt32 oldStatusReasonAux);
+  void changedReasAuxReasToASCII(int axisNo, int functionNamAux0,
+                                 epicsUInt32 statusReasonAux,
+                                 epicsUInt32 oldStatusReasonAux);
 
   struct {
     uint8_t *pIndexerProcessImage;
@@ -483,7 +479,8 @@ class epicsShareClass ethercatmcController : public asynMotorController {
     unsigned numPilsAsynDevInfo;
     int lockADSlineno;
     uint32_t callBackNeeded;
-    char changedAuxBits[MAX_REASON_AUX_BIT_SHOW][36];
+
+    char changedReasAux[MAX_REASON_AUX_BIT_SHOW][36];
 #ifdef ETHERCATMC_TCBSD
     int32_t tcbsdLocalPort;
 #endif
@@ -527,10 +524,6 @@ class epicsShareClass ethercatmcController : public asynMotorController {
     int ethercatmcNamAux21_;
     int ethercatmcNamAux22_;
     int ethercatmcNamAux23_;
-    int ethercatmcNamBit24_;
-    int ethercatmcNamBit25_;
-    int ethercatmcNamBit26_;
-    int ethercatmcNamBit27_;
     int ethercatmcFoffVis_; /* FOFF visible in GUI: motor can be calibrated with
                                setPosition() */
     int ethercatmcHomeVis_; /* HOMF/HOMR visible in GUI (motor can be calibrated

--- a/ethercatmcApp/src/ethercatmcIndexer.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexer.cpp
@@ -716,9 +716,9 @@ indexerParamWritePrintAuxReturn:
     // unsigned idxReasonBits = (statusReasonAux >> 24) & 0x0F;
     unsigned idxAuxBits = statusReasonAux & 0x03FFFFFF;
     if (idxAuxBits != pAxis->drvlocal.clean.old_idxAuxBitsPrinted) {
-      changedAuxBits_to_ASCII(pAxis->axisNo_, defAsynPara.ethercatmcNamAux0_,
-                              idxAuxBits,
-                              pAxis->drvlocal.clean.old_idxAuxBitsPrinted);
+      changedReasAuxReasToASCII(pAxis->axisNo_, defAsynPara.ethercatmcNamAux0_,
+                                idxAuxBits,
+                                pAxis->drvlocal.clean.old_idxAuxBitsPrinted);
       asynPrint(
           pasynUserController_, traceMask,
           "%sindexerParamWrite(%d) idxStatusCode=0x%02X auxBitsOld=0x%06X "
@@ -726,19 +726,19 @@ indexerParamWritePrintAuxReturn:
           "errorID=0x%04X \"%s\" \n",
           modNamEMC, pAxis->axisNo_, idxStatusCode,
           pAxis->drvlocal.clean.old_idxAuxBitsPrinted, idxAuxBits,
-          ctrlLocal.changedAuxBits[0], ctrlLocal.changedAuxBits[1],
-          ctrlLocal.changedAuxBits[2], ctrlLocal.changedAuxBits[3],
-          ctrlLocal.changedAuxBits[4], ctrlLocal.changedAuxBits[5],
-          ctrlLocal.changedAuxBits[6], ctrlLocal.changedAuxBits[7],
-          ctrlLocal.changedAuxBits[8], ctrlLocal.changedAuxBits[9],
-          ctrlLocal.changedAuxBits[10], ctrlLocal.changedAuxBits[11],
-          ctrlLocal.changedAuxBits[12], ctrlLocal.changedAuxBits[13],
-          ctrlLocal.changedAuxBits[14], ctrlLocal.changedAuxBits[15],
-          ctrlLocal.changedAuxBits[16], ctrlLocal.changedAuxBits[17],
-          ctrlLocal.changedAuxBits[18], ctrlLocal.changedAuxBits[19],
-          ctrlLocal.changedAuxBits[20], ctrlLocal.changedAuxBits[21],
-          ctrlLocal.changedAuxBits[22], ctrlLocal.changedAuxBits[23],
-          ctrlLocal.changedAuxBits[24], ctrlLocal.changedAuxBits[25], errorID,
+          ctrlLocal.changedReasAux[0], ctrlLocal.changedReasAux[1],
+          ctrlLocal.changedReasAux[2], ctrlLocal.changedReasAux[3],
+          ctrlLocal.changedReasAux[4], ctrlLocal.changedReasAux[5],
+          ctrlLocal.changedReasAux[6], ctrlLocal.changedReasAux[7],
+          ctrlLocal.changedReasAux[8], ctrlLocal.changedReasAux[9],
+          ctrlLocal.changedReasAux[10], ctrlLocal.changedReasAux[11],
+          ctrlLocal.changedReasAux[12], ctrlLocal.changedReasAux[13],
+          ctrlLocal.changedReasAux[14], ctrlLocal.changedReasAux[15],
+          ctrlLocal.changedReasAux[16], ctrlLocal.changedReasAux[17],
+          ctrlLocal.changedReasAux[18], ctrlLocal.changedReasAux[19],
+          ctrlLocal.changedReasAux[20], ctrlLocal.changedReasAux[21],
+          ctrlLocal.changedReasAux[22], ctrlLocal.changedReasAux[23],
+          ctrlLocal.changedReasAux[24], ctrlLocal.changedReasAux[25], errorID,
           errStringFromErrId(errorID));
       pAxis->drvlocal.clean.old_idxAuxBitsPrinted = idxAuxBits;
     }
@@ -1422,10 +1422,11 @@ int ethercatmcController::newPilsAsynDevice(int axisNo, unsigned devNum,
       myAsynParamType = asynParamFloat64;
       break;
   }
-  /* Aux bits */
-  if (iAllFlags & 0x03FFFFFF) {
+  /* 24 Aux bits. Flags bit 0..23 indicate which aux bit is used and has a name
+   */
+  if (iAllFlags & 0x00FFFFFF) {
     unsigned i;
-    for (i = 0; i < MAX_REASON_AUX_BIT_SHOW; i++) {
+    for (i = 0; i < NUM_AUX_BITS; i++) {
       int function;
       asynStatus status;
       char auxBitname[64];
@@ -1546,32 +1547,54 @@ pilsAsynDevInfo_type *ethercatmcController::findIndexerOutputDevice(
   return NULL;
 }
 
-void ethercatmcController::changedAuxBits_to_ASCII(
+void ethercatmcController::changedReasAuxReasToASCII(
     int axisNo, int functionNamAux0, epicsUInt32 statusReasonAux,
     epicsUInt32 oldStatusReasonAux) {
   /* Show even bit 27..24, which are reson bits, here */
   epicsUInt32 changed = statusReasonAux ^ oldStatusReasonAux;
   epicsUInt32 auxBitIdx;
-  memset(&ctrlLocal.changedAuxBits, 0, sizeof(ctrlLocal.changedAuxBits));
+  memset(&ctrlLocal.changedReasAux, 0, sizeof(ctrlLocal.changedReasAux));
+  size_t length = sizeof(ctrlLocal.changedReasAux[auxBitIdx]) - 2;
   for (auxBitIdx = 0; auxBitIdx < MAX_REASON_AUX_BIT_SHOW; auxBitIdx++) {
     if ((changed >> auxBitIdx) & 0x01) {
-      asynStatus status = asynError;
-      size_t length = sizeof(ctrlLocal.changedAuxBits[auxBitIdx]) - 2;
-      if (functionNamAux0) {
-        int function = (int)(functionNamAux0 + auxBitIdx);
-        /* Leave the first character for '+' or '-',
-           leave one byte for '\0' */
-        status = getStringParam(axisNo, function, (int)length,
-                                &ctrlLocal.changedAuxBits[auxBitIdx][1]);
-      }
-      if (status != asynSuccess) {
-        snprintf(&ctrlLocal.changedAuxBits[auxBitIdx][1], length, "Bit%d",
-                 auxBitIdx);
-      }
-      if ((statusReasonAux >> auxBitIdx) & 0x01) {
-        ctrlLocal.changedAuxBits[auxBitIdx][0] = '+';
+      if (auxBitIdx < NUM_AUX_BITS) {
+        /* Prepare the aux bit names */
+        asynStatus status = asynError;
+        if (functionNamAux0) {
+          int function = (int)(functionNamAux0 + auxBitIdx);
+          /* Leave the first character for '+' or '-',
+             leave one byte for '\0' */
+          status = getStringParam(axisNo, function, (int)length,
+                                  &ctrlLocal.changedReasAux[auxBitIdx][1]);
+        }
+        if (status != asynSuccess) {
+          snprintf(&ctrlLocal.changedReasAux[auxBitIdx][1], length, "Bit%d",
+                   auxBitIdx);
+        }
       } else {
-        ctrlLocal.changedAuxBits[auxBitIdx][0] = '-';
+        /* Prepare the reason bit names */
+        switch (auxBitIdx) {
+          case 27:
+            strncpy(&ctrlLocal.changedReasAux[auxBitIdx][1], "HiLimit", length);
+            break;
+          case 26:
+            strncpy(&ctrlLocal.changedReasAux[auxBitIdx][1], "LoLimit", length);
+            break;
+          case 25:
+            strncpy(&ctrlLocal.changedReasAux[auxBitIdx][1],
+                    "FollErrDynPrblmTimeout", length);
+            break;
+          case 24:
+            strncpy(&ctrlLocal.changedReasAux[auxBitIdx][1],
+                    "StaticPrblmInhibit", length);
+            break;
+        }
+      }
+      /* Add a '+' when the bit becomes true, a '-' when it becomes false */
+      if ((statusReasonAux >> auxBitIdx) & 0x01) {
+        ctrlLocal.changedReasAux[auxBitIdx][0] = '+';
+      } else {
+        ctrlLocal.changedReasAux[auxBitIdx][0] = '-';
       }
     }
   }
@@ -1633,8 +1656,8 @@ asynStatus ethercatmcController::indexerPoll(void) {
                                   &oldStatusReasonAux, 0xFFFFFFFF);
               if ((statusReasonAux ^ oldStatusReasonAux) &
                   maskStatusReasonAux) {
-                changedAuxBits_to_ASCII(axisNo, functionNamAux0,
-                                        statusReasonAux, oldStatusReasonAux);
+                changedReasAuxReasToASCII(axisNo, functionNamAux0,
+                                          statusReasonAux, oldStatusReasonAux);
                 asynPrint(
                     pasynUserController_, traceMask | ASYN_TRACE_INFO,
                     "%spoll(%d) %sOld=0x%04X new=0x%04X "
@@ -1642,21 +1665,21 @@ asynStatus ethercatmcController::indexerPoll(void) {
                     "s)"
                     "\n",
                     modNamEMC, axisNo, paramName, oldStatusReasonAux,
-                    statusReasonAux, ctrlLocal.changedAuxBits[27],
-                    ctrlLocal.changedAuxBits[26], ctrlLocal.changedAuxBits[25],
-                    ctrlLocal.changedAuxBits[24], ctrlLocal.changedAuxBits[0],
-                    ctrlLocal.changedAuxBits[1], ctrlLocal.changedAuxBits[2],
-                    ctrlLocal.changedAuxBits[3], ctrlLocal.changedAuxBits[4],
-                    ctrlLocal.changedAuxBits[5], ctrlLocal.changedAuxBits[6],
-                    ctrlLocal.changedAuxBits[7], ctrlLocal.changedAuxBits[8],
-                    ctrlLocal.changedAuxBits[9], ctrlLocal.changedAuxBits[10],
-                    ctrlLocal.changedAuxBits[11], ctrlLocal.changedAuxBits[12],
-                    ctrlLocal.changedAuxBits[13], ctrlLocal.changedAuxBits[14],
-                    ctrlLocal.changedAuxBits[15], ctrlLocal.changedAuxBits[16],
-                    ctrlLocal.changedAuxBits[17], ctrlLocal.changedAuxBits[18],
-                    ctrlLocal.changedAuxBits[19], ctrlLocal.changedAuxBits[20],
-                    ctrlLocal.changedAuxBits[21], ctrlLocal.changedAuxBits[22],
-                    ctrlLocal.changedAuxBits[23]);
+                    statusReasonAux, ctrlLocal.changedReasAux[27],
+                    ctrlLocal.changedReasAux[26], ctrlLocal.changedReasAux[25],
+                    ctrlLocal.changedReasAux[24], ctrlLocal.changedReasAux[0],
+                    ctrlLocal.changedReasAux[1], ctrlLocal.changedReasAux[2],
+                    ctrlLocal.changedReasAux[3], ctrlLocal.changedReasAux[4],
+                    ctrlLocal.changedReasAux[5], ctrlLocal.changedReasAux[6],
+                    ctrlLocal.changedReasAux[7], ctrlLocal.changedReasAux[8],
+                    ctrlLocal.changedReasAux[9], ctrlLocal.changedReasAux[10],
+                    ctrlLocal.changedReasAux[11], ctrlLocal.changedReasAux[12],
+                    ctrlLocal.changedReasAux[13], ctrlLocal.changedReasAux[14],
+                    ctrlLocal.changedReasAux[15], ctrlLocal.changedReasAux[16],
+                    ctrlLocal.changedReasAux[17], ctrlLocal.changedReasAux[18],
+                    ctrlLocal.changedReasAux[19], ctrlLocal.changedReasAux[20],
+                    ctrlLocal.changedReasAux[21], ctrlLocal.changedReasAux[22],
+                    ctrlLocal.changedReasAux[23]);
               }
             }
             setUIntDigitalParam(axisNo, functionStatusBits,

--- a/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
@@ -115,12 +115,6 @@ ethercatmcIndexerAxis::ethercatmcIndexerAxis(ethercatmcController *pC,
 #ifdef motorNotHomedProblemString
   setIntegerParam(pC_->motorNotHomedProblem_, MOTORNOTHOMEDPROBLEM_ERROR);
 #endif
-  setStringParam(pC_->defAsynPara.ethercatmcNamBit27_, "HiLimit");
-  setStringParam(pC_->defAsynPara.ethercatmcNamBit26_, "LoLimit");
-  setStringParam(pC_->defAsynPara.ethercatmcNamBit25_,
-                 "Dynamic_problem_timeout");
-  setStringParam(pC_->defAsynPara.ethercatmcNamBit24_,
-                 "Static_problem_inhibit");
 
   /* Set the module name to "" if we have FILE/LINE enabled by asyn */
   if (pasynTrace->getTraceInfoMask(pC_->pasynUserController_) &
@@ -1105,29 +1099,29 @@ asynStatus ethercatmcIndexerAxis::doThePoll(bool cached, bool *moving) {
     if (idxAuxBits != drvlocal.clean.old_idxAuxBitsPrinted) {
       /* This is for debugging only: The IOC log will show changed bits */
       /* Show even bit 27..24, which are reson bits, here */
-      pC_->changedAuxBits_to_ASCII(axisNo_, pC_->defAsynPara.ethercatmcNamAux0_,
-                                   idxAuxBits,
-                                   drvlocal.clean.old_idxAuxBitsPrinted);
+      pC_->changedReasAuxReasToASCII(
+          axisNo_, pC_->defAsynPara.ethercatmcNamAux0_, idxAuxBits,
+          drvlocal.clean.old_idxAuxBitsPrinted);
       asynPrint(
           pC_->pasynUserController_, traceMask,
           "%spoll(%d) auxBitsOld=0x%07X new=0x%07X "
           "(%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s) "
           "actPos=%f\n",
           modNamEMC, axisNo_, drvlocal.clean.old_idxAuxBitsPrinted, idxAuxBits,
-          pC_->ctrlLocal.changedAuxBits[27], pC_->ctrlLocal.changedAuxBits[26],
-          pC_->ctrlLocal.changedAuxBits[25], pC_->ctrlLocal.changedAuxBits[24],
-          pC_->ctrlLocal.changedAuxBits[0], pC_->ctrlLocal.changedAuxBits[1],
-          pC_->ctrlLocal.changedAuxBits[2], pC_->ctrlLocal.changedAuxBits[3],
-          pC_->ctrlLocal.changedAuxBits[4], pC_->ctrlLocal.changedAuxBits[5],
-          pC_->ctrlLocal.changedAuxBits[6], pC_->ctrlLocal.changedAuxBits[7],
-          pC_->ctrlLocal.changedAuxBits[8], pC_->ctrlLocal.changedAuxBits[9],
-          pC_->ctrlLocal.changedAuxBits[10], pC_->ctrlLocal.changedAuxBits[11],
-          pC_->ctrlLocal.changedAuxBits[12], pC_->ctrlLocal.changedAuxBits[13],
-          pC_->ctrlLocal.changedAuxBits[14], pC_->ctrlLocal.changedAuxBits[15],
-          pC_->ctrlLocal.changedAuxBits[16], pC_->ctrlLocal.changedAuxBits[17],
-          pC_->ctrlLocal.changedAuxBits[18], pC_->ctrlLocal.changedAuxBits[19],
-          pC_->ctrlLocal.changedAuxBits[20], pC_->ctrlLocal.changedAuxBits[21],
-          pC_->ctrlLocal.changedAuxBits[22], pC_->ctrlLocal.changedAuxBits[23],
+          pC_->ctrlLocal.changedReasAux[27], pC_->ctrlLocal.changedReasAux[26],
+          pC_->ctrlLocal.changedReasAux[25], pC_->ctrlLocal.changedReasAux[24],
+          pC_->ctrlLocal.changedReasAux[0], pC_->ctrlLocal.changedReasAux[1],
+          pC_->ctrlLocal.changedReasAux[2], pC_->ctrlLocal.changedReasAux[3],
+          pC_->ctrlLocal.changedReasAux[4], pC_->ctrlLocal.changedReasAux[5],
+          pC_->ctrlLocal.changedReasAux[6], pC_->ctrlLocal.changedReasAux[7],
+          pC_->ctrlLocal.changedReasAux[8], pC_->ctrlLocal.changedReasAux[9],
+          pC_->ctrlLocal.changedReasAux[10], pC_->ctrlLocal.changedReasAux[11],
+          pC_->ctrlLocal.changedReasAux[12], pC_->ctrlLocal.changedReasAux[13],
+          pC_->ctrlLocal.changedReasAux[14], pC_->ctrlLocal.changedReasAux[15],
+          pC_->ctrlLocal.changedReasAux[16], pC_->ctrlLocal.changedReasAux[17],
+          pC_->ctrlLocal.changedReasAux[18], pC_->ctrlLocal.changedReasAux[19],
+          pC_->ctrlLocal.changedReasAux[20], pC_->ctrlLocal.changedReasAux[21],
+          pC_->ctrlLocal.changedReasAux[22], pC_->ctrlLocal.changedReasAux[23],
           actPosition);
       drvlocal.clean.old_idxAuxBitsPrinted = idxAuxBits;
     }

--- a/ethercatmcApp/src/ethercatmcIndexerV2.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerV2.cpp
@@ -387,7 +387,7 @@ asynStatus ethercatmcController::newIndexerAxisAuxBitsV2(
   /* AUX bits */
   {
     unsigned auxBitIdx = 0;
-    for (auxBitIdx = 0; auxBitIdx < MAX_AUX_BIT_SHOWN; auxBitIdx++) {
+    for (auxBitIdx = 0; auxBitIdx < NUM_AUX_BITS; auxBitIdx++) {
       int function = functionNamAux0 + auxBitIdx;
       if ((iAllFlags >> auxBitIdx) & 1) {
         char auxBitName[34];
@@ -399,7 +399,7 @@ asynStatus ethercatmcController::newIndexerAxisAuxBitsV2(
         asynPrint(pasynUserController_, ASYN_TRACE_INFO,
                   "%sauxBitName(%d) auxBitName@%03u[%02u]=%s\n", modNamEMC,
                   axisNo, functionNamAux0 + auxBitIdx, auxBitIdx, auxBitName);
-        if (function <= functionNamAux0 + MAX_AUX_BIT_SHOWN) {
+        if (function < functionNamAux0 + NUM_AUX_BITS) {
           setStringParam(axisNo, function, auxBitName);
           setAlarmStatusSeverityWrapper(axisNo, function, asynSuccess);
         }
@@ -408,6 +408,7 @@ asynStatus ethercatmcController::newIndexerAxisAuxBitsV2(
         } else {
           if (auxBitIdx < MAX_AUX_BIT_AS_BI_RECORD) {
             char paramName[64];
+
             int function;
             /* construct a parameter name, that is unique by starting
                with AUXBIT */


### PR DESCRIPTION
There are 24 aux bits in the status word. Not all of may be used. The used ones are defined in the flags, retreived in initial reading of the indexer.
When any of the bits are changed (or more than one) there is a printout in the IOC log.
In the same status word there are 4 reason bits defined. Limit switches are indicated here. Other alarms may use them as well on non-motor devices.
To make a long story short:
When printing out the changed bits, 24 aux bits + 4 reason bits have been printed since a long time.
Assuming that everything is a motor, parameters for NamBit27..NamBit24 had been defined. However, devices like Cabinet don't use those at all. Remove all the special handling of bit 24..27.
Cleanup and rename variables to make more clear what is going on.

Changes to be committed:
    modified:   ethercatmcApp/src/ethercatmcController.cpp
    modified:   ethercatmcApp/src/ethercatmcController.h
    modified:   ethercatmcApp/src/ethercatmcIndexer.cpp
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.cpp
    modified:   ethercatmcApp/src/ethercatmcIndexerV2.cpp