### PR TITLE
Revert "Axis: Skip param readback in RESET"

### DIFF
--- a/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
@@ -1068,20 +1068,16 @@ asynStatus ethercatmcIndexerAxis::doThePoll(bool cached, bool *moving) {
     pC_->setAlarmStatusSeverityWrapper(
         axisNo_, pC_->defAsynPara.ethercatmcRBV_TSE_, RBV_TSEstatus);
   }
-  if (idxStatusCode != idxStatusCodeRESET && !localMode) {
-    /* Read back parameters. Do not do it in localMode.
-       Do not do it when axis stays in  reset */
-    if (drvlocal.clean.iTypCode == 0x5010) {
-      pollReadBackParameters(idxAuxBits, paramCtrl, paramfValue);
-      if (drvlocal.clean.iTypCode == 0x5010 ||
-          drvlocal.clean.iTypCode == 0x1E04) {
-        if (!drvlocal.clean.hasPolledAllEnums) {
-          drvlocal.clean.hasPolledAllEnums =
-              readEnumsAndValueAndCallbackIntoMbbi();
-        }
-      }
+  /* Read back parameters. Do not do it in localMode */
+  if (!localMode && drvlocal.clean.iTypCode == 0x5010) {
+    pollReadBackParameters(idxAuxBits, paramCtrl, paramfValue);
+  }
+  if (drvlocal.clean.iTypCode == 0x5010 || drvlocal.clean.iTypCode == 0x1E04) {
+    if (!drvlocal.clean.hasPolledAllEnums) {
+      drvlocal.clean.hasPolledAllEnums = readEnumsAndValueAndCallbackIntoMbbi();
     }
   }
+
   if ((idxStatusCode != drvlocal.dirty.idxStatusCodeLog) ||
       (errorID != drvlocal.dirty.old_ErrorIdLog)) {
     if (errorID) {


### PR DESCRIPTION
- Revert previous PR: https://github.com/EuropeanSpallationSource/m-epics-ethercatmc/pull/41

This whole block

if (drvlocal.clean.iTypCode == 0x5010 ||
          drvlocal.clean.iTypCode == 0x1E04) {
        if (!drvlocal.clean.hasPolledAllEnums) {
          drvlocal.clean.hasPolledAllEnums =
              readEnumsAndValueAndCallbackIntoMbbi();
        }
    }
Should be moved one line down. At the moment, it is inside the conditional if (drvlocal.clean.iTypCode == 0x5010), which will make drvlocal.clean.iTypCode == 0x1E04 to never be true.

This issue wasn't noticed in my test deployment because we looked only into the electric motors (0x5010)