### PR TITLE
ethercatmcController.cpp: look at interruptAccept again

### DIFF
--- a/ethercatmcApp/src/ethercatmcController.cpp
+++ b/ethercatmcApp/src/ethercatmcController.cpp
@@ -770,6 +770,13 @@ void ethercatmcController::handleStatusChangeFL(asynStatus status,
 asynStatus ethercatmcController::poll(void) {
   asynStatus status = asynSuccess;
 
+  asynPrint(pasynUserController_, ASYN_TRACE_FLOW,
+            "%spoll interruptAccept=%d ctrlLocal.initialPollDone=%d\n",
+            modNamEMC, interruptAccept, ctrlLocal.initialPollDone);
+  if (!interruptAccept) {
+    return asynSuccess;
+  }
+
   ctrlLocal.callBackNeeded = 0;
   if (!ctrlLocal.initialPollDone) {
     status = indexerInitialPoll();

--- a/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
@@ -624,6 +624,13 @@ int ethercatmcIndexerAxis::readEnumsAndValueAndCallbackIntoMbbi(void) {
         &auxBitEnumsForAsyn.enumChars[auxBitIdx][0];
     status = pC_->getStringParam(axisNo_, function, length,
                                  auxBitEnumsForAsyn.enumStrings[auxBitIdx]);
+
+    asynPrint(pC_->pasynUserController_, ASYN_TRACE_FLOW,
+              "%sreadEnumsAndValueAndCallbackIntoMbbi(%d) auxBitIdx=%u "
+              "name='%s' status=%d\n",
+              modNamEMC, axisNo_, auxBitIdx,
+              auxBitEnumsForAsyn.enumStrings[auxBitIdx], (int)status);
+
     if (status) {
       break;
     }


### PR DESCRIPTION
The big cleanup removing non-used code did remove the interruptAccept check in the poller.
Basically commit fad8129c
    ethercatmcController.cpp: Take care about interruptAccept

was unintentionally removed.
The effect was that the definition for mbbi records was lost, ethercatmcIndexerAxis::readEnumsAndValueAndCallbackIntoMbbi() did not have any effect.
Add a debug print in ethercatmcIndexerAxis.cpp

Solution:
Restore the handling of interruptAccept in the poller.

Changes to be committed:
    modified:   ethercatmcApp/src/ethercatmcController.cpp
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.cpp