### PR TITLE
Reset the -ErrRst PV to 0 when reset is done

### DIFF
--- a/ethercatmcApp/Db/ethercatmc.template
+++ b/ethercatmcApp/Db/ethercatmc.template
@@ -142,8 +142,8 @@ record(longout,"$(P)$(R)-ErrRst") {
     field(DESC, "Error Reset")
     field(VAL,  0)
     field(DTYP, "asynInt32")
-    field(PINI, "YES")
     field(OUT,"@asyn($(MOTOR_PORT),$(AXIS_NO))ErrRst")
+    info(asyn:READBACK,"1")
 }
 
 # Motor offset for this axis

--- a/ethercatmcApp/src/ethercatmcIndexerAxis.h
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.h
@@ -90,7 +90,6 @@ class epicsShareClass ethercatmcIndexerAxis : public asynMotorAxis {
   asynStatus doThePoll(bool cached, bool *moving);
   void pollErrTxtMsgTxt(int hasError, int errorID, unsigned idxAuxBits,
                         int localMode, unsigned statusReasonAux);
-  asynStatus resetAxis(void);
   bool pollPowerIsOn(void);
   asynStatus setClosedLoop(bool closedLoop);
   asynStatus setGenericIntegerParam(int function, int value);


### PR DESCRIPTION
The "-ErrRst" PV triggers a reset command inside the motion controller. However, once a "1" is written to it, it stays at "1" forever. However, when "1" is written again, a new reset is send to the controller.

Improve the behaviour of the record:
Reset it to "0" once the reset has been done inside the controller.

While there, integrate the one-line-method resetAxis() into the code.

Changes to be committed:
    modified:   ethercatmcApp/Db/ethercatmc.template
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.cpp
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.h