### PR TITLE
Remove setSAFxxxViaADS

### DIFF
--- a/ethercatmcApp/src/ethercatmcController.h
+++ b/ethercatmcApp/src/ethercatmcController.h
@@ -354,21 +354,6 @@ class epicsShareClass ethercatmcController : public asynMotorController {
   asynStatus getSymbolHandleByNameViaADS(const char *symbolName,
                                          uint32_t *handle);
 
-  asynStatus setSAFIntegerOnAxisViaADSFL(unsigned indexGroup,
-                                         unsigned indexOffset, int value,
-                                         size_t lenInPlc, const char *fileName,
-                                         int lineNo);
-
-#define setSAFIntegerOnAxisViaADS(a, b, c, d) \
-  setSAFIntegerOnAxisViaADSFL(a, b, c, d, __FILE__, __LINE__)
-
-  asynStatus setSAFDoubleOnAxisViaADSFL(unsigned indexGroup,
-                                        unsigned indexOffset, double value,
-                                        size_t lenInPlc, const char *fileName,
-                                        int lineNo);
-#define setSAFDoubleOnAxisViaADS(a, b, c, d) \
-  setSAFDoubleOnAxisViaADSFL(a, b, c, d, __FILE__, __LINE__)
-
   /* IndexerV2 */
   asynStatus readDeviceIndexerV2FL(unsigned devNum, unsigned infoType,
                                    void *bufptr, size_t buflen,

--- a/ethercatmcApp/src/ethercatmcIndexer.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexer.cpp
@@ -316,52 +316,6 @@ asynStatus ethercatmcController::setPlcMemoryDouble(unsigned indexOffset,
   }
 }
 
-asynStatus ethercatmcController::setSAFIntegerOnAxisViaADSFL(
-    unsigned indexGroup, unsigned indexOffset, int value, size_t lenInPlc,
-    const char *fileName, int lineNo) {
-  const static unsigned targetAdsport = 501;
-  asynStatus status;
-  if (lenInPlc <= 8) {
-    uint8_t raw[8];
-    uintToNet(value, &raw, lenInPlc);
-
-    status = setMemIdxGrpIdxOffFL(indexGroup, indexOffset, targetAdsport, &raw,
-                                  lenInPlc, fileName, lineNo);
-    asynPrint(
-        pasynUserController_, ASYN_TRACE_INFO,
-        "%s%s:%d setSAFIntegerOnAxisViaADSFL indexGroup=0x%X indexOffset=0x%X"
-        " value=%d lenInPlc=%u status=%s (%d)\n",
-        modNamEMC, fileName, lineNo, indexGroup, indexOffset, value,
-        (unsigned)lenInPlc, ethercatmcstrStatus(status), (int)status);
-    return status;
-  } else {
-    return asynError;
-  }
-}
-
-asynStatus ethercatmcController::setSAFDoubleOnAxisViaADSFL(
-    unsigned indexGroup, unsigned indexOffset, double value, size_t lenInPlc,
-    const char *fileName, int lineNo) {
-  const static unsigned targetAdsport = 501;
-  asynStatus status;
-  if (lenInPlc == 8 || lenInPlc == 4) {
-    uint8_t raw[8];
-    doubleToNet(value, &raw, lenInPlc);
-
-    status = setMemIdxGrpIdxOffFL(indexGroup, indexOffset, targetAdsport, &raw,
-                                  lenInPlc, fileName, lineNo);
-    asynPrint(
-        pasynUserController_, ASYN_TRACE_INFO,
-        "%s%s:%d setSAFIntegerOnAxisViaADSFL indexGroup=0x%X indexOffset=0x%X"
-        " value=%f lenInPlc=%u status=%s (%d)\n",
-        modNamEMC, fileName, lineNo, indexGroup, indexOffset, value,
-        (unsigned)lenInPlc, ethercatmcstrStatus(status), (int)status);
-    return status;
-  } else {
-    return asynError;
-  }
-}
-
 asynStatus ethercatmcController::indexerWaitSpecialDeviceIdle(
     unsigned indexOffset) {
   unsigned traceMask = ASYN_TRACE_FLOW;


### PR DESCRIPTION
Remove the not needed methods setSAFIntegerOnAxisViaADS() and setSAFDoubleOnAxisViaADS() including the xxxFL wrappers printing with File and Line.
Both methods are not used with the indexer. All this is handled inside the MCU. Remove not used code here.

Changes to be committed:
   modified:   ethercatmcApp/src/ethercatmcController.h
   modified:   ethercatmcApp/src/ethercatmcIndexer.cpp