### PR TITLE
Fix st.pneumatic-MCU031-CI0021330.iocsh

### DIFF
--- a/test/startup/st.pneumatic-MCU031-CI0021330.iocsh
+++ b/test/startup/st.pneumatic-MCU031-CI0021330.iocsh
@@ -23,7 +23,6 @@ epicsEnvSet("R",               "Shutter")
 epicsEnvSet("AXIS_NO",         "1")
 epicsEnvSet("DESC",            "$(SM_DESC=DESC)")
 epicsEnvSet("EGU",             "$(SM_EGU=EGU)")
-epicsEnvSet("R",               "Shutter-")
 < ethercatmcShutter.iocsh
 
 # Pressure


### PR DESCRIPTION
Testing the "pneumatics with errorid" showed the the $(R) macro was wrong in st.pneumatic-MCU031-CI0021330.iocsh Fix it.