### PR TITLE
Allow moveVel while moveVel is ongoing; overhaul paramIF

### DIFF
--- a/ethercatmcApp/src/ethercatmcController.cpp
+++ b/ethercatmcApp/src/ethercatmcController.cpp
@@ -52,12 +52,6 @@ const static char *const strethercatmcStartPollerDef = "ethercatmcStartPoller";
 
 const static char *const modulName = "ethercatmc::";
 
-extern "C" double ethercatmcgetNowTimeSecs(void) {
-  epicsTimeStamp nowTime;
-  epicsTimeGetCurrent(&nowTime);
-  return nowTime.secPastEpoch + (nowTime.nsec * 0.000000001);
-}
-
 extern "C" const char *errStringFromErrId(int nErrorId) {
   switch (nErrorId) {
     case 0x0707:

--- a/ethercatmcApp/src/ethercatmcController.h
+++ b/ethercatmcApp/src/ethercatmcController.h
@@ -146,6 +146,13 @@ typedef enum {
   idxStatusCodeERR15 = 15
 } idxStatusCodeType;
 
+extern "C" {
+typedef struct {
+  uint8_t paramCtrl[2];
+  uint8_t paramValueRaw[8]; /* May be 4 or 8 bytes */
+} paramIf_type;
+};
+
 /**********************************************************************/
 #define ethercatmchexdump(pasynUser, tracelevel, help_txt, bufptr, buflen,     \
                           fName, lNo)                                          \
@@ -209,6 +216,7 @@ typedef struct {
 } pilsAsynDevInfo_type;
 }
 extern "C" {
+double ethercatmcgetNowTimeSecs(void);
 unsigned netToUint(const void *data, size_t lenInPlc);
 int netToSint(const void *data, size_t lenInPlc);
 double netToDouble(const void *data, size_t lenInPlc);
@@ -403,12 +411,18 @@ class epicsShareClass ethercatmcController : public asynMotorController {
                                 size_t lenInPlc);
 
   asynStatus indexerWaitSpecialDeviceIdle(unsigned indexOffset);
+  asynStatus indexerParamIFIdle(unsigned paramIfOffset,
+                                unsigned lenInPLCparamIf,
+                                paramIf_type *pParamIf, int *pParmaIfReady);
   asynStatus indexerParamReadFL(ethercatmcIndexerAxis *pAxis,
                                 unsigned paramIfOffset, unsigned paramIndex,
                                 double *value, const char *fileName,
                                 int lineNo);
 #define indexerParamRead(a, b, c, d) \
   indexerParamReadFL(a, b, c, d, __FILE__, __LINE__)
+  asynStatus indexerParamIfInternal(ethercatmcIndexerAxis *pAxis,
+                                    unsigned paramIfCmd, unsigned paramIndex,
+                                    double value, double *pValueRB);
   asynStatus indexerParamWrite(ethercatmcIndexerAxis *pAxis,
                                unsigned paramIndex, double value,
                                double *pValueRB);

--- a/ethercatmcApp/src/ethercatmcIndexerAxis.h
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.h
@@ -47,10 +47,6 @@ extern "C" {
 int ethercatmcCreateIndexerAxis(const char *ethercatmcName, int axisNo,
                                 int axisFlags, const char *axisOptionsStr);
 const char *paramIfCmdToString(unsigned cmdSubParamIndex);
-typedef struct {
-  uint8_t paramCtrl[2];
-  uint8_t paramValueRaw[8]; /* May be 4 or 8 bytes */
-} paramIf_type;
 };
 
 class epicsShareClass ethercatmcIndexerAxis : public asynMotorAxis {
@@ -151,6 +147,7 @@ class epicsShareClass ethercatmcIndexerAxis : public asynMotorAxis {
       char customParaNames[PARAM_IF_NUM_CUSTOM_PARAS][34];
       int asynFunctionAuxBitAsBiRecord[MAX_AUX_BIT_AS_BI_RECORD];
     } clean;
+    double paramIFstartTime;
     int pollScaling;
   } drvlocal;
 


### PR DESCRIPTION
Major overhaul of the parameter interface:
- detect a timeout by looking at the time spend, not a blind counter
- refactor commeon code for read- and write
- faster polling when waiting for the parameter interface to be done or to become idle. This should speed up all parameter handling, especially important for controllers with many axes.

Allow the change of JVEL when jogging:
  The model 3 driver will call moveVelocity() a second time with the new velocity. This lead to a stop() before. Now it is allowed from here. Note: the MCU needs to be prepared: Put the param interface into DONE instead of keeping it in BUSY while jogging.

Changes to be committed:
    modified:   ethercatmcApp/src/ethercatmcController.cpp
    modified:   ethercatmcApp/src/ethercatmcController.h
    modified:   ethercatmcApp/src/ethercatmcIndexer.cpp
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.cpp
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.h