### PR TITLE
Better handling of flickering encoder when not busy

### DIFF
--- a/ethercatmcApp/src/ethercatmcIndexerAxis.h
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.h
@@ -138,7 +138,6 @@ class epicsShareClass ethercatmcIndexerAxis : public asynMotorAxis {
       unsigned old_idxAuxBitsWritten;
       unsigned int hasProblem : 1;
       unsigned int hasPolledAllEnums : 1;
-      unsigned int hasPARAM_IDX_SETPOINT_FLOAT : 1;
       uint8_t
           pollNowParams[128]; /* 0 terminated list of parameters to be polled */
       PILSparamPermType PILSparamPerm[256];


### PR DESCRIPTION
When we have a high-resolution encoder it may give us a new actual postion in every poll().
The current code updates the direction bit force and back, resulting in a change of the MSTA field in the motorRecord. And the TDIR field as well.
The changed position can be filtered out with help of ADEL/MDEL. Looking at TDIR:
It is definded as "travelling direction".

Solution:
Update direction only when the motor is not activly moving. While there, clean the code up.
Additionally, set the moving bit first when the first change of actual position is detected.
Reset moving when the controller is not busy any more.

Changes to be committed:
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.cpp
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.h