### PR TITLE
ethercatmcIndexerAxis: Allow JOG and JVEL change

### DIFF
--- a/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
@@ -509,6 +509,22 @@ asynStatus ethercatmcIndexerAxis::moveVelocity(double minVelocity,
   (void)acceleration;
 
   pC_->getIntegerParam(axisNo_, pC_->motorStatusDone_, &motorStatusDone);
+
+#ifdef motorLatestCommandString
+  {
+    int motorLatestCommand = 0;
+    pC_->getIntegerParam(axisNo_, pC_->motorLatestCommand_,
+                         &motorLatestCommand);
+    asynPrint(pC_->pasynUserController_, traceMask,
+              "%smoveVelocity (%d) minVelocity=%f maxVelocity=%f"
+              " acceleration=%f motorStatusDone=%d motorLatestCommand=%d\n",
+              modNamEMC, axisNo_, minVelocity, maxVelocity, acceleration,
+              motorStatusDone, motorLatestCommand);
+    if ((motorLatestCommand != LATEST_COMMAND_MOVE_VEL) && (!motorStatusDone)) {
+      stopAxisInternal("moveVelocity", acceleration);
+    }
+  }
+#else
   asynPrint(pC_->pasynUserController_, traceMask,
             "%smoveVelocity (%d) minVelocity=%f maxVelocity=%f"
             " acceleration=%f motorStatusDone=%d\n",
@@ -518,6 +534,7 @@ asynStatus ethercatmcIndexerAxis::moveVelocity(double minVelocity,
   if (!motorStatusDone) {
     stopAxisInternal("moveVelocity", acceleration);
   }
+#endif
   if ((acceleration > 0.0) &&
       (drvlocal.clean.PILSparamPerm[PARAM_IDX_ACCEL_FLOAT] ==
        PILSparamPermWrite)) {


### PR DESCRIPTION
Some controllers do allow the change of the velocity while moving with constant velocity.
This can be triggered by writing to the JOGF/JOGR field in the motorRecord and, while the motor is moving, write a new value to theJVEL field.
The generic driver will call moveVelocity() again, with a new value for maxVelocity.

Allow this combination,
when we know that that the last call was a moveVelocity.