### PR TITLE
Use Err: in asynPrint(...ASYN_TRACE_ERROR)

### DIFF
--- a/ethercatmcApp/src/ethercatmcADS.cpp
+++ b/ethercatmcApp/src/ethercatmcADS.cpp
@@ -243,8 +243,8 @@ asynStatus ethercatmcController::writeReadControllerADS(
   if (nwrite != outlen) {
     if (ctrlLocal.cntADSstatus < MAXCNTADSSTATUS) {
       asynPrint(
-          pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-          "%s:%d outlen=%lu nwrite=%lu timeout=%f err=%s status=%s (%d)\n",
+          pasynUser, ASYN_TRACE_ERROR,
+          "%s:%d Err: outlen=%lu nwrite=%lu timeout=%f err=%s status=%s (%d)\n",
           fileName, lineNo, (unsigned long)outlen, (unsigned long)nwrite,
           DEFAULT_CONTROLLER_TIMEOUT, pasynUser->errorMessage,
           ethercatmcstrStatus(status), status);
@@ -323,9 +323,9 @@ asynStatus ethercatmcController::writeReadControllerADS(
                       "", 0);
   }
   if ((status == asynTimeout) || (errorProblem & 8)) {
-    asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-              "%s status=%s errorProblem=%d: calling disconnect_C\n", modNamEMC,
-              ethercatmcstrStatus(status), errorProblem);
+    asynPrint(pasynUser, ASYN_TRACE_ERROR,
+              "%s Err: status=%s errorProblem=%d: calling disconnect_C\n",
+              modNamEMC, ethercatmcstrStatus(status), errorProblem);
     status = asynError;
     disconnect_C(pasynUser);
   }
@@ -363,12 +363,13 @@ asynStatus ethercatmcController::writeReadAds(
     uint32_t amsTcpHdr_len_act = NETTOUINT(ams_rep_hdr_p->amsTcpHdr.net_len);
 
     if ((!status) && (amsTcpHdr_len_act != amsTcpHdr_len_exp)) {
-      asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                "%s:%d nread=%u calling disconnect_C: amsTcpHdr_len_exp=%u "
-                "0x%08X amsTcpHdr_len_act=%u 0x%08X\n",
-                fileName, lineNo, (unsigned)nread, (unsigned)amsTcpHdr_len_exp,
-                (unsigned)amsTcpHdr_len_exp, (unsigned)amsTcpHdr_len_act,
-                (unsigned)amsTcpHdr_len_act);
+      asynPrint(
+          pasynUser, ASYN_TRACE_ERROR,
+          "%s:%d Err: nread=%u calling disconnect_C: amsTcpHdr_len_exp=%u "
+          "0x%08X amsTcpHdr_len_act=%u 0x%08X\n",
+          fileName, lineNo, (unsigned)nread, (unsigned)amsTcpHdr_len_exp,
+          (unsigned)amsTcpHdr_len_exp, (unsigned)amsTcpHdr_len_act,
+          (unsigned)amsTcpHdr_len_act);
       disconnect_C(pasynUser);
       status = asynError;
     }
@@ -376,12 +377,13 @@ asynStatus ethercatmcController::writeReadAds(
       uint32_t ads_rep_len_exp = nread - sizeof(AmsHdrType);
       uint32_t ads_rep_len_act = NETTOUINT(ams_rep_hdr_p->net_len);
       if (ads_rep_len_act != ads_rep_len_exp) {
-        asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                  "%s:%d nread=%u calling disconnect_C: ads_rep_len_exp=%u  "
-                  "0x%08X ads_rep_len_act=%u 0x%08X \n",
-                  fileName, lineNo, (unsigned)nread, (unsigned)ads_rep_len_exp,
-                  (unsigned)ads_rep_len_exp, (unsigned)ads_rep_len_act,
-                  (unsigned)ads_rep_len_act);
+        asynPrint(
+            pasynUser, ASYN_TRACE_ERROR,
+            "%s:%d Err: nread=%u calling disconnect_C: ads_rep_len_exp=%u  "
+            "0x%08X ads_rep_len_act=%u 0x%08X \n",
+            fileName, lineNo, (unsigned)nread, (unsigned)ads_rep_len_exp,
+            (unsigned)ads_rep_len_exp, (unsigned)ads_rep_len_act,
+            (unsigned)ads_rep_len_act);
         disconnect_C(pasynUser);
         status = asynError;
       }
@@ -421,8 +423,8 @@ asynStatus ethercatmcController::writeReadAds(
                           lineNo);
         ethercatmcamsdump(pasynUser, tracelevel, "IN ", indata, nread);
 
-        asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                  "%s nread=%u ams_errorCode=0x%x\n", modNamEMC,
+        asynPrint(pasynUser, ASYN_TRACE_ERROR,
+                  "%s Err: nread=%u ams_errorCode=0x%x\n", modNamEMC,
                   (unsigned)nread, (unsigned)ams_errorCode);
         status = asynError;
       }
@@ -430,8 +432,8 @@ asynStatus ethercatmcController::writeReadAds(
     if (!status) {
       uint32_t rep_invokeID = NETTOUINT(ams_rep_hdr_p->net_invokeID);
       if (invokeID != rep_invokeID) {
-        asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                  "%s:%d calling disconnect_C: invokeID=%u 0x%08X "
+        asynPrint(pasynUser, ASYN_TRACE_ERROR,
+                  "%s:%d Err: calling disconnect_C: invokeID=%u 0x%08X "
                   "rep_invokeID=%u 0x%08X\n",
                   fileName, lineNo, (unsigned)invokeID, (unsigned)invokeID,
                   (unsigned)rep_invokeID, (unsigned)rep_invokeID);
@@ -525,8 +527,8 @@ asynStatus ethercatmcController::getPlcMemoryViaADSFL(unsigned indexOffset,
                 (unsigned)ads_result);
       status = asynError;
     } else if (ads_length != lenInPlc) {
-      asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                "%s:%d ERROR lenInPlc=%lu ads_length=%u\n", fileName, lineNo,
+      asynPrint(pasynUser, ASYN_TRACE_ERROR,
+                "%s:%d Err: lenInPlc=%lu ads_length=%u\n", fileName, lineNo,
                 (unsigned long)lenInPlc, (unsigned)ads_length);
       status = asynError;
     }
@@ -623,9 +625,8 @@ asynStatus ethercatmcController::setMemIdxGrpIdxOffFL(
       ethercatmchexdump(pasynUser, tracelevel, "WRMEM", data, lenInPlc,
                         fileName, lineNo);
 
-      asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                "%s:%d ads_result=0x%x\n", fileName, lineNo,
-                (unsigned)ads_result);
+      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%d Err: ads_result=0x%x\n",
+                fileName, lineNo, (unsigned)ads_result);
       status = asynError;
     }
   }
@@ -679,8 +680,8 @@ asynStatus ethercatmcController::getSymbolInfoViaADS(const char *symbolName,
     uint32_t ads_result = NETTOUINT(adsReadWriteRep_p->response.net_res);
     uint32_t ads_length = NETTOUINT(adsReadWriteRep_p->response.net_len);
     if (ads_result) {
-      asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                "%sERROR ads_result=0x%x\n", modNamEMC, (unsigned)ads_result);
+      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%sErr: ads_result=0x%x\n",
+                modNamEMC, (unsigned)ads_result);
       status = asynError;
     }
     if (!status) {
@@ -748,8 +749,8 @@ asynStatus ethercatmcController::getSymbolHandleByNameViaADS(
     uint32_t ads_result = NETTOUINT(adsReadWriteRep_p->response.net_res);
     uint32_t ads_length = NETTOUINT(adsReadWriteRep_p->response.net_len);
     if (ads_result) {
-      asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                "%sERROR ads_result=0x%x\n", modNamEMC, (unsigned)ads_result);
+      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%sErr: ads_result=0x%x\n",
+                modNamEMC, (unsigned)ads_result);
       status = asynError;
     }
     if (!status) {

--- a/ethercatmcApp/src/ethercatmcController.cpp
+++ b/ethercatmcApp/src/ethercatmcController.cpp
@@ -420,7 +420,7 @@ ethercatmcController::ethercatmcController(const char *portName,
       pasynOctetSyncIO->connect(MotorPortName, 0, &pasynUserController_, NULL);
   if (status) {
     asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-              "%s cannot connect to motor controller\n", modulName);
+              "%s Err: cannot connect to motor controller\n", modulName);
   }
   printf("%s:%d %s optionStr=\"%s\"\n", __FILE__, __LINE__, modulName,
          optionStr ? optionStr : "NULL");
@@ -640,13 +640,12 @@ extern "C" asynStatus disconnect_C(asynUser *pasynUser) {
     pasynCommon = (asynCommon *)pasynInterface->pinterface;
     status = pasynCommon->disconnect(pasynInterface->drvPvt, pasynUser);
     if (status != asynSuccess) {
-      asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                "%s status=%s (%d)\n", modulName, ethercatmcstrStatus(status),
-                (int)status);
+      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s Err: status=%s (%d)\n",
+                modulName, ethercatmcstrStatus(status), (int)status);
     }
   } else {
-    asynPrint(pasynUser, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-              "%s pasynInterface=%p pasynCommon=%p\n", modulName,
+    asynPrint(pasynUser, ASYN_TRACE_ERROR,
+              "%s Err: pasynInterface=%p pasynCommon=%p\n", modulName,
               pasynInterface, pasynCommon);
   }
   return status;

--- a/ethercatmcApp/src/ethercatmcIndexer.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexer.cpp
@@ -350,8 +350,8 @@ asynStatus ethercatmcController::indexerParamReadFL(
   asynStatus status;
   if (!pAxis || (paramIndex > 0xFF) ||
       (pAxis->drvlocal.clean.iTypCode != 0x5010)) {
-    asynPrint(pasynUserController_, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-              "%s pAxis=%p paramIndex=%u typeCode=0x%x\n", modNamEMC, pAxis,
+    asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
+              "%sErr: pAxis=%p paramIndex=%u typeCode=0x%x\n", modNamEMC, pAxis,
               paramIndex, pAxis->drvlocal.clean.iTypCode);
     return asynError;
   }
@@ -411,8 +411,8 @@ asynStatus ethercatmcController::indexerParamWrite(ethercatmcIndexerAxis *pAxis,
 
   if (!pAxis || (paramIndex > 0xFF) ||
       (pAxis->drvlocal.clean.iTypCode != 0x5010)) {
-    asynPrint(pasynUserController_, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-              "%s pAxis=%p paramIndex=%u typeCode=0x%x\n", modNamEMC, pAxis,
+    asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
+              "%sErr: pAxis=%p paramIndex=%u typeCode=0x%x\n", modNamEMC, pAxis,
               paramIndex, pAxis->drvlocal.clean.iTypCode);
     return asynError;
   }
@@ -457,8 +457,8 @@ asynStatus ethercatmcController::indexerParamIfInternal(
     lenInPlcPara = pAxis->drvlocal.clean.lenInPlcParaFloat[paramIndex];
   }
   if (!paramIfOffset || lenInPlcPara > sizeof(paramIf_to_MCU.paramValueRaw)) {
-    asynPrint(pasynUserController_, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-              "%s pAxis=%p lenInPlcPara=%u paramIfOffset=%u \n", modNamEMC,
+    asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
+              "%sErr: pAxis=%p lenInPlcPara=%u paramIfOffset=%u \n", modNamEMC,
               pAxis, lenInPlcPara, paramIfOffset);
     return asynError;
   }
@@ -467,8 +467,8 @@ asynStatus ethercatmcController::indexerParamIfInternal(
          PILSparamPermRead) ||
         (pAxis->drvlocal.clean.PILSparamPerm[paramIndex] ==
          PILSparamPermNone)) {
-      asynPrint(pasynUserController_, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                "%s pAxis=%p paramIndex=%u lenInPlcPara=%u paramIfOffset=%u "
+      asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
+                "%sErr pAxis=%p paramIndex=%u lenInPlcPara=%u paramIfOffset=%u "
                 "perm=%d\n",
                 modNamEMC, pAxis, paramIndex, lenInPlcPara, paramIfOffset,
                 (int)pAxis->drvlocal.clean.PILSparamPerm[paramIndex]);
@@ -476,16 +476,17 @@ asynStatus ethercatmcController::indexerParamIfInternal(
     }
   } else if (paramIfCmd == PARAM_IF_CMD_DOREAD) {
     if (pAxis->drvlocal.clean.PILSparamPerm[paramIndex] == PILSparamPermNone) {
-      asynPrint(pasynUserController_, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                "%s pAxis=%p paramIndex=%u lenInPlcPara=%u paramIfOffset=%u "
-                "perm=%d\n",
-                modNamEMC, pAxis, paramIndex, lenInPlcPara, paramIfOffset,
-                (int)pAxis->drvlocal.clean.PILSparamPerm[paramIndex]);
+      asynPrint(
+          pasynUserController_, ASYN_TRACE_ERROR,
+          "%sErr: pAxis=%p paramIndex=%u lenInPlcPara=%u paramIfOffset=%u "
+          "perm=%d\n",
+          modNamEMC, pAxis, paramIndex, lenInPlcPara, paramIfOffset,
+          (int)pAxis->drvlocal.clean.PILSparamPerm[paramIndex]);
       return asynError;
     }
   } else {
-    asynPrint(pasynUserController_, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-              "%sindexerParamIfInternal(%d) %s(%u 0x%02X) %s(0x%02X)\n",
+    asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
+              "%sErr: indexerParamIfInternal(%d) %s(%u 0x%02X) %s(0x%02X)\n",
               modNamEMC, axisNo,
               plcParamIndexTxtFromParamIndex(paramIndex, axisNo), paramIndex,
               paramIndex, paramIfCmdToString(paramIfCmd), paramIfCmd);
@@ -604,12 +605,12 @@ asynStatus ethercatmcController::indexerParamIfInternal(
               }
             }
             if (status != asynSuccess) {
-              asynPrint(
-                  pasynUserController_, ASYN_TRACE_ERROR | ASYN_TRACEIO_DRIVER,
-                  "%s pAxis=%p paramIndex=%u lenInPlcPara=%u "
-                  "paramIfOffset=%u status=%s (%d)\n",
-                  modNamEMC, pAxis, paramIndex, lenInPlcPara, paramIfOffset,
-                  ethercatmcstrStatus(status), (int)status);
+              asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
+                        "%sErr: pAxis=%p paramIndex=%u lenInPlcPara=%u "
+                        "paramIfOffset=%u status=%s (%d)\n",
+                        modNamEMC, pAxis, paramIndex, lenInPlcPara,
+                        paramIfOffset, ethercatmcstrStatus(status),
+                        (int)status);
               goto indexerParamIfInternalPrintAuxReturn;
             }
           } break;
@@ -1129,19 +1130,21 @@ int ethercatmcController::addPilsAsynDevLst(
       &ctrlLocal.pilsAsynDevInfo[numPilsAsynDevInfo];
 
   if (numPilsAsynDevInfo >= maxNumPilsAsynDevInfo) {
-    asynPrint(pasynUserController_, ASYN_TRACE_ERROR, "%s%s(%u) out of range\n",
-              modNamEMC, functionName, numPilsAsynDevInfo);
+    asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
+              "%s%s Err: (%u) out of range\n", modNamEMC, functionName,
+              numPilsAsynDevInfo);
     return -1;
   }
 
-  asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
-            "%s%s axisNo=%i \"%s\" functionNamAux0=%d functionStatusBits=%d "
-            "lenInPLC=%u inputOffset=%u outputOffset=%u statusOffset=%u"
-            " EPICSParamType=%s(%i) iTypeCode=0x%04X\n",
-            modNamEMC, functionName, axisNo, paramName, functionNamAux0,
-            functionStatusBits, lenInPLC, inputOffset, outputOffset,
-            statusOffset, stringFromAsynParamType(myEPICSParamType),
-            (int)myEPICSParamType, iTypCode);
+  asynPrint(
+      pasynUserController_, ASYN_TRACE_ERROR,
+      "%s%s Err: axisNo=%i \"%s\" functionNamAux0=%d functionStatusBits=%d "
+      "lenInPLC=%u inputOffset=%u outputOffset=%u statusOffset=%u"
+      " EPICSParamType=%s(%i) iTypeCode=0x%04X\n",
+      modNamEMC, functionName, axisNo, paramName, functionNamAux0,
+      functionStatusBits, lenInPLC, inputOffset, outputOffset, statusOffset,
+      stringFromAsynParamType(myEPICSParamType), (int)myEPICSParamType,
+      iTypCode);
   asynPrint(pasynUserController_, ASYN_TRACE_INFO,
             "%s%s(%u) \"%s\" EPICSParamType=%s(%i)\n", modNamEMC, functionName,
             axisNo, paramName, stringFromAsynParamType(myEPICSParamType),
@@ -1652,7 +1655,7 @@ asynStatus ethercatmcController::indexerPoll(void) {
               status = setIntegerParam(axisNo, function, newValue);
               if (status == asynParamWrongType) {
                 asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
-                          "%sindexerPoll(%d) ERROR: need to disable "
+                          "%sErr: indexerPoll(%d) need to disable "
                           "function=%s(%d) status=%s (%d)\n",
                           modNamEMC, axisNo, paramName, function,
                           ethercatmcstrStatus(status), (int)status);
@@ -1701,7 +1704,7 @@ asynStatus ethercatmcController::indexerPoll(void) {
                   break;
                 default:
                   asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
-                            "%sindexerPoll(%d) ERROR: newValueValid = 0 "
+                            "%sErr: indexerPoll(%d) newValueValid = 0 "
                             "function=%s(%d)\n",
                             modNamEMC, axisNo, paramName, function);
                   newValueValid = 0;
@@ -1713,7 +1716,7 @@ asynStatus ethercatmcController::indexerPoll(void) {
                   status = setDoubleParam(axisNo, function, newValue);
                   if (status == asynParamWrongType) {
                     asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
-                              "%sindexerPoll(%d) ERROR: need to disable "
+                              "%sErr: indexerPoll(%d) need to disable "
                               "function=%s(%d) status=%s (%d)\n",
                               modNamEMC, axisNo, paramName, function,
                               ethercatmcstrStatus(status), (int)status);
@@ -1744,7 +1747,7 @@ asynStatus ethercatmcController::indexerPoll(void) {
               status = setInteger64Param(axisNo, function, newValue);
               if (status == asynParamWrongType) {
                 asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
-                          "%sindexerPoll(%d) ERROR: need to disable "
+                          "%sErr:sindexerPoll(%d) need to disable "
                           "function=%s(%d) status=%s (%d)\n",
                           modNamEMC, axisNo, paramName, function,
                           ethercatmcstrStatus(status), (int)status);


### PR DESCRIPTION
Make more clear which prints are errors and which are not. Always use the word "Err:" at the beginning of the line.

Note:
code like this is OK:
   asynPrint(pasynUserController_, ASYN_TRACE_ERROR,
             "%s%sErr: (%u) out of range\n", modNamEMC, functionName,

... since modNamEMC does have trailing space.

In opposite to
    asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
              "%s Err: cannot connect to motor controller\n", modulName);
where we need a space after "%s"

Changes to be committed:
    modified:   ethercatmcApp/src/ethercatmcADS.cpp
    modified:   ethercatmcApp/src/ethercatmcController.cpp
    modified:   ethercatmcApp/src/ethercatmcIndexer.cpp