### PR TITLE
add generic binary output with readback support

### DIFF
--- a/ethercatmcApp/Db/ethercatmcBinaryOutReadback.template
+++ b/ethercatmcApp/Db/ethercatmcBinaryOutReadback.template
@@ -1,0 +1,10 @@
+record(bo, "$(P)$(R)")
+{
+    field(DTYP, "asynInt32")
+    field(DESC, "$(DESC)")
+    field(OUT,  "@asyn($(MOTOR_PORT),$(CHNO))$(ASYNPARAMNAME)")
+    field(ZNAM, "$(ZNAM)")
+    field(ONAM, "$(ONAM)")
+    info(asyn:READBACK,"1")
+    info(asyn:INITIAL_READBACK,"1")
+}

--- a/iocsh/ethercatmcBinaryOutReadback.iocsh
+++ b/iocsh/ethercatmcBinaryOutReadback.iocsh
@@ -1,0 +1,3 @@
+ethercatmcCreateAsynParam $(MOTOR_PORT) $(ASYNPARAMNAME) Int32
+
+dbLoadRecords("ethercatmcBinaryOutReadback.template", "P=$(P), R=$(R), MOTOR_PORT=$(MOTOR_PORT), CHNO=$(CHNO), ASYNPARAMNAME=$(ASYNPARAMNAME), DESC=$(DESC), ZNAM=$(ZNAM), ONAM=$(ONAM)")


### PR DESCRIPTION
We already have similar records for motors (eg. Clutch, Brake). It's useful to have a more generic record that can be used to enable or disable devices not necessarily linked to one axis like a compressor, for instance.

Added the READBACK infotag to keep track of state in the PLC.