### PR TITLE
simulator: Implement the ADS_READSTATE command

### DIFF
--- a/test/simulator/ads.c
+++ b/test/simulator/ads.c
@@ -170,6 +170,7 @@ void handleADSwrite(int fd, ams_hdr_type *ams_hdr_p) {
   }
 }
 
+/* This function is only used by the ads driver */
 void handleADSreadwrite(int fd, ams_hdr_type *ams_hdr_p) {
   ADS_ReadWrite_req_type *ADS_ReadWrite_req_p =
       (ADS_ReadWrite_req_type *)ams_hdr_p;

--- a/test/simulator/ads.h
+++ b/test/simulator/ads.h
@@ -7,6 +7,7 @@
 #define ADS_READ_DEVICE_INFO 1
 #define ADS_READ 2
 #define ADS_WRITE 3
+#define ADS_READSTATE 4
 #define ADS_READ_WRITE 9
 
 /* AMS/TCP Header */
@@ -99,6 +100,20 @@ typedef struct {
   uint8_t wr_len_3;
   uint8_t data[256];
 } ADS_ReadWrite_req_type;
+
+typedef struct {
+  ams_hdr_type ams_hdr;
+  struct {
+    uint8_t result_0;
+    uint8_t result_1;
+    uint8_t result_2;
+    uint8_t result_3;
+    uint8_t adsState_low;
+    uint8_t adsState_high;
+    uint8_t deviceState_low;
+    uint8_t deviceState_high;
+  } response;
+} ADS_Read_State_rep_type;
 
 typedef struct {
   ams_hdr_type ams_hdr;

--- a/test/simulator/sock-ads.c
+++ b/test/simulator/sock-ads.c
@@ -83,12 +83,28 @@ size_t handle_ams_request(int fd, char *buf, size_t len, size_t buff_len_max) {
     handleADSwrite(fd, ams_hdr_p);
     indexerHandlePLCcycle();
     return len;
+  } else if (cmdId == ADS_READSTATE) {
+    ADS_Read_State_rep_type *ADS_Read_State_rep_p =
+        (ADS_Read_State_rep_type *)ams_hdr_p;
+    uint32_t total_len_reply;
+    total_len_reply = sizeof(*ADS_Read_State_rep_p);
+    memset(&ADS_Read_State_rep_p->response, 0,
+           sizeof(ADS_Read_State_rep_p->response));
+    /* only adsstate is need and must be run.
+       Leave the rest as 0 */
+    ADS_Read_State_rep_p->response.adsState_low = 5; /* ADSSTATE_RUN */
+    // ADS_Read_State_rep_p->response.adsState_high;
+    // ADS_Read_State_rep_p->response.deviceState_low;
+    // ADS_Read_State_rep_p->response.deviceState_high;
+    send_ams_reply(fd, ams_hdr_p, total_len_reply);
+    return len;
   } else if (cmdId == ADS_READ_WRITE) {
     handleADSreadwrite(fd, ams_hdr_p);
-    RETURN_ERROR_OR_DIE(__LINE__, "%s/%s:%d command not implemented =%u",
+    RETURN_ERROR_OR_DIE(__LINE__,
+                        "%s/%s:%d command readWrite not implemented =%u",
                         __FILE__, __FUNCTION__, __LINE__, cmdId);
   } else {
-    RETURN_ERROR_OR_DIE(__LINE__, "%s/%s:%d command not implemented =%u",
+    RETURN_ERROR_OR_DIE(__LINE__, "%s/%s:%d command not implemented=%u",
                         __FILE__, __FUNCTION__, __LINE__, cmdId);
   }
 


### PR DESCRIPTION
The twincat-ads driver reads the state of the device. It must be running.
Implement it in the simulator.

Changes to be committed:
    modified:   test/simulator/ads.c
    modified:   test/simulator/ads.h
    modified:   test/simulator/sock-ads.c