### PR TITLE
MsgTxt: prioritize interlock state over not homed

### DIFF
--- a/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
@@ -1487,10 +1487,6 @@ void ethercatmcIndexerAxis::pollMsgTxt(int hasError, int errorID,
     charEorW = 'W';
     snprintf(sErrorMessage, sizeof(sErrorMessage) - 1, "%c: %s", charEorW,
              "PowerOff");
-  } else if (!homed) {
-    charEorW = 'W';
-    snprintf(sErrorMessage, sizeof(sErrorMessage) - 1, "%c: %s", charEorW,
-             "Axis not homed");
   }
   /* TODO:
   axis can not be moved at all: poweroff, localmode, interlock, axis in
@@ -1499,29 +1495,77 @@ void ethercatmcIndexerAxis::pollMsgTxt(int hasError, int errorID,
   /* continue with msgtxt */
   if (!nowMoving) {
     /* A moving axis should show moving, homing ...*/
+    const unsigned interlockMask = drvlocal.clean.auxBitsInterlockFwdMask |
+                                   drvlocal.clean.auxBitsInterlockBwdMask;
+    const unsigned interlockBits = statusReasonAux & interlockMask;
+    const int hasInterlockMask = interlockMask != 0;
     if (sErrorMessage[0]) {
       msgTxtFromDriver =
           &sErrorMessage[0]; /* There is an important text already */
     } else if (localMode) {
       charEorW = 'W';
       msgTxtFromDriver = "W: localMode";
-    } else if (statusReasonAux & (drvlocal.clean.auxBitsInterlockFwdMask |
-                                  drvlocal.clean.auxBitsInterlockBwdMask)) {
-      if (((statusReasonAux & (drvlocal.clean.auxBitsInterlockFwdMask |
-                               drvlocal.clean.auxBitsInterlockBwdMask)) ==
-           drvlocal.clean.auxBitsInterlockFwdMask)) {
+    } else if (hasInterlockMask &&
+               interlockBits == (drvlocal.clean.auxBitsInterlockFwdMask |
+                                 drvlocal.clean.auxBitsInterlockBwdMask)) {
+      /* Both Fwd and Bwd interlocked: axis cannot move at all, show before
+      homing */
+      charEorW = 'W';
+      msgTxtFromDriver = "W: InterlockFwdBwd";
+    } else if (!homed) {
+      /* Single-direction interlock: check if it blocks the configured homing
+       * direction. If it does, the interlock message takes priority over
+       * "not homed" since homing will fail. Otherwise homing may still succeed
+       * in the free direction, so "not homed" takes priority. */
+      int homProc = 0;
+      pC_->getIntegerParam(axisNo_, pC_->defAsynPara.ethercatmcHomProc_RB_,
+                           &homProc);
+      /* FWD homing procedures: LimFwd=2, HSfwdfromLimFwd=4, HSfwd=12,
+       *                        IndexNFwd=22, IndexNfromLimFwd=24 */
+      static const int fwdHomProcs[] = {2, 4, 12, 22, 24};
+      /* BWD homing procedures: LimBwd=1, HSbwdfromLimBwd=3, HSbwd=11,
+       *                        IndexNBwd=21, IndexNfromLimBwd=23 */
+      static const int bwdHomProcs[] = {1, 3, 11, 21, 23};
+      static const size_t numFwdHomProcs =
+          sizeof(fwdHomProcs) / sizeof(fwdHomProcs[0]);
+      static const size_t numBwdHomProcs =
+          sizeof(bwdHomProcs) / sizeof(bwdHomProcs[0]);
+      int homingIsFwd = 0, homingIsBwd = 0;
+      for (size_t i = 0; i < numFwdHomProcs; i++) {
+        if (homProc == fwdHomProcs[i]) {
+          homingIsFwd = 1;
+          break;
+        }
+      }
+      for (size_t i = 0; i < numBwdHomProcs; i++) {
+        if (homProc == bwdHomProcs[i]) {
+          homingIsBwd = 1;
+          break;
+        }
+      }
+      if (hasInterlockMask &&
+          interlockBits == drvlocal.clean.auxBitsInterlockFwdMask &&
+          homingIsFwd) {
         charEorW = 'W';
         msgTxtFromDriver = "W: InterlockFwd";
-      } else if (((statusReasonAux &
-                   (drvlocal.clean.auxBitsInterlockFwdMask |
-                    drvlocal.clean.auxBitsInterlockBwdMask)) ==
-                  drvlocal.clean.auxBitsInterlockBwdMask)) {
+      } else if (hasInterlockMask &&
+                 interlockBits == drvlocal.clean.auxBitsInterlockBwdMask &&
+                 homingIsBwd) {
         charEorW = 'W';
         msgTxtFromDriver = "W: InterlockBwd";
       } else {
         charEorW = 'W';
-        msgTxtFromDriver = "W: InterlockFwdBwd";
+        snprintf(sErrorMessage, sizeof(sErrorMessage) - 1, "%c: %s", charEorW,
+                 "Axis not homed");
       }
+    } else if (hasInterlockMask &&
+               interlockBits == drvlocal.clean.auxBitsInterlockFwdMask) {
+      charEorW = 'W';
+      msgTxtFromDriver = "W: InterlockFwd";
+    } else if (hasInterlockMask &&
+               interlockBits == drvlocal.clean.auxBitsInterlockBwdMask) {
+      charEorW = 'W';
+      msgTxtFromDriver = "W: InterlockBwd";
     } else if (errorID) {
       charEorW = 'W';
       const char *errIdString = errStringFromErrId(errorID);

--- a/test/pytests36/941_Simulator-MsgTxt.py
+++ b/test/pytests36/941_Simulator-MsgTxt.py
@@ -109,6 +109,9 @@ idleWarnTCs = [
     (20, "0x104C0000", 0x0, 0, "W: InterlockFwdBwd"),
     # homed (bit set), enabled, custom error id
     (21, "0x10420000", 0x10101, 0, "W: MotorNotHomed"),
+    # not homed, enabled, InterlockFwdBwd: both directions blocked, axis cannot
+    # move at all, InterlockFwdBwd must appear before "Axis not homed"
+    (22, "0x10CC0000", 0x0, 0, "W: InterlockFwdBwd"),
 ]
 
 errorTCs = [
@@ -138,6 +141,35 @@ resetTCs = [
     (1, "0x00000000", 0x0, 0, "W: AxisRESET"),
     # Reset state. errorID should be ignored
     (2, "0x00000000", 0x4550, 0, "W: AxisRESET"),
+]
+
+# Test cases for HomProc-aware interlock vs not-homed priority.
+# Tuple: (tc_no, statusReasonAux, errorId, pwrAuto, homProc, expMsgTxt)
+# HomProc values: LimBwd=1, LimFwd=2, HSbwdfromLimBwd=3, HSfwdfromLimFwd=4,
+#                 HSbwd=11, HSfwd=12, IndexNBwd=21, IndexNFwd=22,
+#                 IndexNfromLimBwd=23, IndexNfromLimFwd=24, ManSetPos=15
+interlockHomProcTCs = [
+    # not homed, enabled, InterlockFwd, HomProc goes FWD (LimFwd=2):
+    # homing is blocked by InterlockFwd -> show InterlockFwd before not homed
+    (1, "0x10C40000", 0x0, 0, 2, "W: InterlockFwd"),
+    # not homed, enabled, InterlockBwd, HomProc goes BWD (LimBwd=1):
+    # homing is blocked by InterlockBwd -> show InterlockBwd before not homed
+    (2, "0x10C80000", 0x0, 0, 1, "W: InterlockBwd"),
+    # not homed, enabled, InterlockFwd, HomProc goes BWD (LimBwd=1):
+    # homing direction is free -> show not homed first
+    (3, "0x10C40000", 0x0, 0, 1, "W: Axis not homed"),
+    # not homed, enabled, InterlockBwd, HomProc goes FWD (LimFwd=2):
+    # homing direction is free -> show not homed first
+    (4, "0x10C80000", 0x0, 0, 2, "W: Axis not homed"),
+    # not homed, enabled, InterlockFwd, HomProc unknown (ManSetPos=15):
+    # direction not known -> show not homed first
+    (5, "0x10C40000", 0x0, 0, 15, "W: Axis not homed"),
+    # not homed, enabled, InterlockFwd, HomProc=HSfwd(12) (FWD):
+    # homing is blocked -> show InterlockFwd before not homed
+    (6, "0x10C40000", 0x0, 0, 12, "W: InterlockFwd"),
+    # not homed, enabled, InterlockBwd, HomProc=HSbwd(11) (BWD):
+    # homing is blocked -> show InterlockBwd before not homed
+    (7, "0x10C80000", 0x0, 0, 11, "W: InterlockBwd"),
 ]
 
 
@@ -207,9 +239,7 @@ class Test(unittest.TestCase):
     drvUseEGU_RB = None
     drvUseEGU = 0
     url_string = os.getenv("TESTEDMOTORAXIS")
-    print(
-        f"{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {filnam} url_string={url_string}"
-    )
+    print(f"{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {filnam} url_string={url_string}")
 
     axisCom = AxisCom(url_string, log_debug=False)
     axisMr = AxisMr(axisCom)
@@ -332,6 +362,43 @@ class Test(unittest.TestCase):
                 expSevr=sevrMajor,
                 expStat=STATE_ALARM,
             )
+
+        assert passed
+
+    def test_TC_94104(self):
+        passed = True
+        for tc in interlockHomProcTCs:
+            tc_no = 94104000 + tc[0]
+            statusReasonAux = tc[1]
+            errorId = tc[2]
+            pwrAuto = tc[3]
+            homProc = tc[4]
+            expMsgTxt = tc[5]
+            # reset to clean state first
+            passed = passed and writeBitsReadMsgTxt(
+                self,
+                tc_no=tc_no,
+                statusReasonAux=statusReasonAuxIdlePowerOn,
+                errorId=0,
+                pwrAuto=1,
+                expMsgTxt="",
+                expSevr=sevrNone,
+                expStat=NONE_ALARM,
+            )
+            tc_no = 94104100 + tc[0]
+            oldHomProc = self.axisCom.get("-HomProc")
+            self.axisCom.put("-HomProc", homProc, wait=True)
+            passed = passed and writeBitsReadMsgTxt(
+                self,
+                tc_no=tc_no,
+                statusReasonAux=statusReasonAux,
+                errorId=errorId,
+                pwrAuto=pwrAuto,
+                expMsgTxt=expMsgTxt,
+                expSevr=sevrMinor,
+                expStat=STATE_ALARM,
+            )
+            self.axisCom.put("-HomProc", oldHomProc, wait=True)
 
         assert passed
 


### PR DESCRIPTION
If a motor is both interlocked (fwd/bwd) and not homed, MsgTxt was showing not homed first. This induced users to try to home, but, being interlocked, movement was not possible. Fix that by showing interlock state before homed state in MsgTxt priorities.