### PR TITLE
Allow HLSV to be configured from .iocsh file

### DIFF
--- a/ethercatmcApp/Db/ethercatmc.template
+++ b/ethercatmcApp/Db/ethercatmc.template
@@ -28,6 +28,7 @@ record(motor,"$(P)$(R)")
 	field(FOFF,"$(FOFF=0)")
 	field(NTM,"0")
 	field(TWV,"$(TWV=1)")
+	field(HLSV,"$(HLSV=0)")
 }
 
 # The message text

--- a/iocsh/ethercatmcIndexerAxis.iocsh
+++ b/iocsh/ethercatmcIndexerAxis.iocsh
@@ -1,6 +1,6 @@
 ethercatmcCreateIndexerAxis("$(MOTOR_PORT)", "$(AXIS_NO)", "6", "$(AXISCONFIG)")
 
-dbLoadRecords("ethercatmc.template", "P=$(P), R=$(R), MOTOR_PORT=$(MOTOR_PORT), ASYN_PORT=$(ASYN_PORT), AXIS_NO=$(AXIS_NO), PREC=$(PREC), RAWENCSTEP_ADEL=$(RAWENCSTEP_ADEL), RAWENCSTEP_MDEL=$(RAWENCSTEP_MDEL) $(ECAXISFIELDINIT)")
+dbLoadRecords("ethercatmc.template", "P=$(P), R=$(R), MOTOR_PORT=$(MOTOR_PORT), ASYN_PORT=$(ASYN_PORT), AXIS_NO=$(AXIS_NO), PREC=$(PREC), HLSV=$(HLSV=0), RAWENCSTEP_ADEL=$(RAWENCSTEP_ADEL), RAWENCSTEP_MDEL=$(RAWENCSTEP_MDEL) $(ECAXISFIELDINIT)")
 
 dbLoadRecords("ethercatmcAuxBitsStatus.template", "P=$(P), R=$(R), AXIS_NO=$(AXIS_NO), MOTOR_PORT=$(MOTOR_PORT), ASYN_PORT=$(ASYN_PORT), AXIS_NO=$(AXIS_NO) ")
 


### PR DESCRIPTION
In normal conditions, the limit switches should be protected by the soft limits. However, if by some human mistake or failure the limits are activated, we may need to know that. Allow users to optionally set HLSV via .iocsh file.
The default value of 0 was added for retro-compatibility and making the new argument optional.

A next addition: show a message text if LLS or HLS are active. Priority to be discussed.