### PR TITLE
Handle the Coupled aux bit

### DIFF
--- a/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
@@ -304,6 +304,13 @@ void ethercatmcIndexerAxis::setAuxBitsCustomErrIdMask(
   drvlocal.clean.auxBitsCustomErrIdMask = auxBitsCustomErrIdMask;
 }
 
+void ethercatmcIndexerAxis::setAuxBitsCoupledMask(unsigned auxBitsCoupledMask) {
+  asynPrint(pC_->pasynUserController_, ASYN_TRACE_INFO,
+            "%s(%d) auxBitsCoupledMask=0x%X\n", modNamEMC, axisNo_,
+            auxBitsCoupledMask);
+  drvlocal.clean.auxBitsCoupledMask = auxBitsCoupledMask;
+}
+
 void ethercatmcIndexerAxis::addPollNowParam(uint8_t paramIndex) {
   size_t pollNowIdx;
   const size_t pollNowIdxMax = sizeof(drvlocal.clean.pollNowParams) /
@@ -1105,6 +1112,9 @@ asynStatus ethercatmcIndexerAxis::doThePoll(bool cached, bool *moving) {
   }
   if (idxStatusCode != idxStatusCodeRESET) {
     setIntegerParam(pC_->defAsynPara.ethercatmcErrRst_, 0);
+    if (statusReasonAux & drvlocal.clean.auxBitsCoupledMask) {
+      busyNotDone = true;
+    }
   }
   *moving = busyNotDone;
   /* These is important to inform the motorRecord
@@ -1605,6 +1615,10 @@ void ethercatmcIndexerAxis::pollMsgTxt(int hasError, int errorID,
   reset state axis can be partly moved: Limit switch, interlock Fwd/Bwd axis
   is not homed ??? axis can be moved */
   /* continue with msgtxt */
+  if (statusReasonAux & drvlocal.clean.auxBitsCoupledMask) {
+    msgTxtFromDriver = "Coupled";
+    charEorW = 'W';
+  }
   if (!nowMoving) {
     if (sErrorMessage[0]) {
       msgTxtFromDriver =

--- a/ethercatmcApp/src/ethercatmcIndexerAxis.h
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.h
@@ -75,6 +75,7 @@ class epicsShareClass ethercatmcIndexerAxis : public asynMotorAxis {
   void setAuxBitsLimitSwFwdMask(unsigned auxBitsLimitSwFwdMask);
   void setAuxBitsLimitSwBwdMask(unsigned auxBitsLimitSwBwdMask);
   void setAuxBitsCustomErrIdMask(unsigned auxBitsCustomErrIdMask);
+  void setAuxBitsCoupledMask(unsigned auxBitsCoupledMask);
   void setAuxBitsEnabledMask(unsigned auxBitsEnabledMask);
   void setAuxBitsLocalModeMask(unsigned auxBitsLocalModeMask);
   void setAuxBitsHomeSwitchMask(unsigned auxBitsHomeSwitchMask);
@@ -140,6 +141,7 @@ class epicsShareClass ethercatmcIndexerAxis : public asynMotorAxis {
       unsigned auxBitsLimitSwFwdMask;
       unsigned auxBitsLimitSwBwdMask;
       unsigned auxBitsCustomErrIdMask;
+      unsigned auxBitsCoupledMask;
       unsigned old_paramCtrl;
       unsigned old_idxAuxBitsPrinted;
       unsigned old_idxAuxBitsWritten;

--- a/ethercatmcApp/src/ethercatmcIndexerV2.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerV2.cpp
@@ -449,6 +449,8 @@ asynStatus ethercatmcController::newIndexerAxisAuxBitsV2(
             pAxis->setAuxBitsLimitSwBwdMask(1 << auxBitIdx);
           } else if (!strcmp("customErrId", auxBitName)) {
             pAxis->setAuxBitsCustomErrIdMask(1 << auxBitIdx);
+          } else if (!strcmp("Coupled", auxBitName)) {
+            pAxis->setAuxBitsCoupledMask(1 << auxBitIdx);
           }
         }
       } else {

--- a/test/pytests36/941_Simulator-MsgTxt.py
+++ b/test/pytests36/941_Simulator-MsgTxt.py
@@ -113,6 +113,8 @@ idleWarnTCs = [
     # not homed, enabled, HI+LO_ilock: both directions blocked, axis cannot
     # move at all, HI+LO_ilock must appear before Axis not homed
     (22, 0x10CC0000, 0x0, 0, "W: HI+LO interlocks"),
+    # homed (bit set), enabled, coupled
+    (23, 0x10410000, 0x0, 0, "Coupled"),
 ]
 
 errorTCs = [

--- a/test/simulator/indexer.c
+++ b/test/simulator/indexer.c
@@ -677,7 +677,7 @@ indexerDeviceAbsStraction_type indexerDeviceAbsStraction[NUM_DEVICES] = {
       "",
       "",
       "",
-      "",
+      "Coupled",
       "customErrId",
       "InterlockFwd",
       "InterlockBwd",


### PR DESCRIPTION
Handle the new aux bit "Coupled".
It means that the motor is busy, from an EPICS motorRecord point of view. At the end of the busy period, the motorRecord will synchronize VAL from RBV.So far we set the motor to

For the user information the MsgTxt "Coupled" will be shown; Add a test case and code inside the simulator.

Changes to be committed:
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.cpp
    modified:   ethercatmcApp/src/ethercatmcIndexerAxis.h
    modified:   ethercatmcApp/src/ethercatmcIndexerV2.cpp
    modified:   test/pytests36/941_Simulator-MsgTxt.py
    modified:   test/simulator/indexer.c