### PR TITLE
ethercatmcIndexerV2: Fix plcname on reconnect

### DIFF
--- a/ethercatmcApp/src/ethercatmcIndexerV2.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerV2.cpp
@@ -283,6 +283,7 @@ asynStatus ethercatmcController::indexerInitialPollv2(void) {
     } else {
 #ifdef motorMessageTextString
       /* We find the name of the MCU here */
+      setIntegerParam(0, motorStatusCommsError_, 0);
       setStringParam(0, motorMessageText_, descVersAuthors.desc);
 #endif
       ctrlLocal.indexerMaxDataSize =


### PR DESCRIPTION
Fix a "has been there a long time" problem:
When the connection is lost and now re-established the PlcName stayed in "E: Communication".
Solution: Tell the generic motor driver, that axisno == 0 is no longer an communication error. And then write the PlcName, as before.