### PR TITLE
ethercatmcIndexerAxis: pollMsgTxt and moving

### DIFF
--- a/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
+++ b/ethercatmcApp/src/ethercatmcIndexerAxis.cpp
@@ -1405,7 +1405,7 @@ asynStatus ethercatmcIndexerAxis::doThePoll(bool cached, bool *moving) {
         drvlocal.dirty.motorPowerAutoOnOff ||
         drvlocal.dirty.idxStatusCodeMsgTxt != idxStatusCode ||
         idxAuxBits != drvlocal.clean.old_idxAuxBitsWritten ||
-        idxAuxBits != drvlocal.dirty.old_idxAuxBits) {
+        idxAuxBits != drvlocal.dirty.old_idxAuxBits || busyNotDone) {
       pollMsgTxt(hasError, errorID, idxAuxBits, localMode, statusReasonAux, hls,
                  lls, motorRecDirection > 0);
       drvlocal.dirty.motorPowerAutoOnOff = 0;


### PR DESCRIPTION
Found an (old? new?) bug:
When a motor was not homed, the msgtxt did show
"W: Axis not homed"

When the homing is started, the msgtxt should change to "Homing" but didnt.
The call to pollMsgTxt() is only called when e.g.
one of the aux bits had changed.
It is not fully why this has been working before and not now anymore.
To be on the save side, we call pollMsgTxt() when the motor is moving.