### PR TITLE
Add an iocsh and template for a longin record

### DIFF
--- a/ethercatmcApp/Db/Makefile
+++ b/ethercatmcApp/Db/Makefile
@@ -34,6 +34,7 @@ DB += ethercatmcEL6688-PTP.template
 DB += ethercatmcEL6688-PTP-twincat-ads.template
 DB += ethercatmcEL6688-EL1252-PTP.template
 DB += ethercatmcEL6688-EL1252-PTP-POS-NEG.template
+DB += ethercatmcLongin.template
 DB += ethercatmcMotorTemp.template
 DB += ethercatmcOpenClutch.template
 DB += ethercatmcReleaseBrake.template

--- a/ethercatmcApp/Db/ethercatmcLongin.template
+++ b/ethercatmcApp/Db/ethercatmcLongin.template
@@ -1,0 +1,9 @@
+record(longin, "$(P)$(R)")
+{
+    field(DTYP, "asynInt32")
+    field(DESC, "$(DESC=DESC)")
+    field(EGU,  "$(EGU=EGU)")
+    field(INP,  "@asyn($(MOTOR_PORT),$(CHNO))$(ASYNPARAMNAME)")
+    field(SCAN, "I/O Intr")
+    field(TSE,  "$(TSE=0)")
+}

--- a/iocsh/ethercatmcLongin.iocsh
+++ b/iocsh/ethercatmcLongin.iocsh
@@ -1,0 +1,3 @@
+ethercatmcCreateAsynParam $(MOTOR_PORT) $(ASYNPARAMNAME)      Int32
+
+dbLoadRecords("ethercatmcLongin.template", "P=$(P), R=$(R), MOTOR_PORT=$(MOTOR_PORT), CHNO=$(CHNO), ASYNPARAMNAME=$(ASYNPARAMNAME), DESC=$(DESC), EGU=$(EGU)")


### PR DESCRIPTION
Make it possible to use a longin record.

Changes to be committed:
modified:   ethercatmcApp/Db/Makefile
    new file:   ethercatmcApp/Db/ethercatmcLongin.template
    new file:   iocsh/ethercatmcLongin.iocsh