### PR TITLE
Temporarily pin ruff version to 0.15.22.

### DIFF
--- a/.github/workflows/ci-scripts-ruff.yml
+++ b/.github/workflows/ci-scripts-ruff.yml
@@ -7,3 +7,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
+        with:
+          # temporarily pin until migration to ruff > 0.16 is possible (see https://github.com/EuropeanSpallationSource/m-epics-ethercatmc/issues/107)
+          version: 0.15.22

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: 23.9.1
     hooks:
       - id: black
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.292
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.22
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
-[tool.ruff]
+[tool.ruff.lint]
 extend-select = ["D212"]
 extend-ignore = ["D105", "D107", "D202", "D418", "E501"]

--- a/test/pytests36/runTests.sh
+++ b/test/pytests36/runTests.sh
@@ -248,10 +248,10 @@ fi
 TERM=dumb black *.py || exit
 
 #Check ruff, the fast Python linter and code formatter
-# Note: The version without 'v'. 'v' is used when installing
-RUFF_VERSION=0.1.7
+# Pin exact Ruff version to avoid 0.16+ behavior changes for now
+RUFF_VERSION=0.15.22
 if ! ruff --version | grep -q "[^0-9]${RUFF_VERSION}$"; then
-  pip install git+https://github.com/charliermarsh/ruff-pre-commit@v$RUFF_VERSION
+  pip install ruff==$RUFF_VERSION
 fi
 if ! ruff --version | grep -q "[^0-9]${RUFF_VERSION}$"; then
   echo >&2 ruff not found or wrong version


### PR DESCRIPTION
So far we have used a pipeline with unpinned ruff version. After update to 0.16.0, which added a lot of new rules, the codebase started to fail a lot of checks. For now, pin to latest compatible version (0.15.22) until we can fix the codebase to comply with the new rules.

Also updated the local runner to use the same version instead of the very old one it was using.
For more info, see [1].

[1]- https://github.com/astral-sh/ruff/releases/tag/0.16.0